### PR TITLE
Add email sending to user-api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 __pycache__
 .garden
+*.sublime-workspace

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ To have fun building stuff from the ground up and to keep myself practiced in va
 ## Running
 
 One of the targets of this project is to have as few dependencies as possible. Currently the project's only hard requirement is a modern kubernetes cluster. There are a few softer requirements, listed below in descending order of difficulty to change:
+* Sendgrid for email
+    * Used by user-api for email verification and password resets. Can be disabled, but those features won't be available. Switching to another email provider would take a moderate amount of work.
 * CloudFlare for DNS
-    * Currently expected in the external-dns configuration defined in [scripts/cluster-init](scripts/cluster-init/setup-external-dns.sh), very little work to adapt.
+    * Currently expected in the external-dns configuration defined in [cluster-init](scripts/cluster-init/setup-external-dns.sh), very little work to adapt.
+    * Has some CNAME records to sendgrid domains so they can add SPF records to validate outbound emails. Switching DNS would require going through domain verification and setup through sendgrid again.
 * Vultr for hosting the kubernetes cluster
     * PVCs all over set `vultr-block-storage` as their `storageClass`, but this is very simple to adapt for other providers.
 

--- a/auth-api/container/auth_api/routers/api_models.py
+++ b/auth-api/container/auth_api/routers/api_models.py
@@ -40,3 +40,17 @@ class RegisterRequest(BaseModel):
     first_name: str
     last_name: str
     verify_code: str
+
+
+class RequestResetPasswordRequest(BaseModel):
+    email_address: str
+
+
+class RequestResetPasswordResponse(BaseModel):
+    reset_code: Optional[str]
+
+
+class ResetPasswordRequest(BaseModel):
+    email_address: str
+    password: str
+    reset_code: str

--- a/auth-api/container/auth_api/routers/api_models.py
+++ b/auth-api/container/auth_api/routers/api_models.py
@@ -1,18 +1,19 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 
-class RegisterRequest(BaseModel):
-    username: str
+class ChangeNameRequest(BaseModel):
+    first_name: str
+    last_name: str
+
+
+class ChangePasswordRequest(BaseModel):
     password: str
 
 
-class LoginResponse(BaseModel):
-    access_token: str
-    token_type: str = "bearer"
-
-
 class LoginJsonRequest(BaseModel):
-    username: str
+    email_address: str
     password: str
 
 
@@ -20,5 +21,22 @@ class LoginJsonResponse(BaseModel):
     client_token: str
 
 
-class ChangePasswordRequest(BaseModel):
+class LoginResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class PreRegisterRequest(BaseModel):
+    email_address: str
+
+
+class PreRegisterResponse(BaseModel):
+    verify_code: Optional[str]
+
+
+class RegisterRequest(BaseModel):
+    email_address: str
     password: str
+    first_name: str
+    last_name: str
+    verify_code: str

--- a/auth-api/container/auth_api/routers/dependencies.py
+++ b/auth-api/container/auth_api/routers/dependencies.py
@@ -10,20 +10,20 @@ from auth_api.services import user_api
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl=f"{config.EXPECTED_PREFIX}/login")
 
 
-def get_username(token: str = Depends(oauth2_scheme)) -> str:
+def get_email_address(token: str = Depends(oauth2_scheme)) -> str:
     """Validate that a token is valid."""
     try:
-        username = user_api.username_from_token(token)
+        email_address = user_api.email_address_from_token(token)
     except NotFoundError:
         raise HTTPException(status_code=401, detail="Token invalid or expired")
     except Exception as e:
         with sanitize_excs():
             raise e
-    return username
+    return email_address
 
 
 def get_token(token: str = Depends(oauth2_scheme)) -> str:
     """Validate that a token is valid."""
     # 401 / whatever else will propagate if necessary
-    get_username(token)
+    get_email_address(token)
     return token

--- a/auth-api/container/auth_api/routers/main.py
+++ b/auth-api/container/auth_api/routers/main.py
@@ -19,14 +19,42 @@ def ping() -> str:
     return "pong"
 
 
+@app.post("/preregister")
+def preregister(
+    pre_register_request: api_models.PreRegisterRequest,
+) -> api_models.PreRegisterResponse:
+    """Pre-register a new user, subitting their email for verification."""
+    with sanitize_excs():
+        verify_code = user_api.preregister(
+            email_address=pre_register_request.email_address
+        )
+        resp = api_models.PreRegisterResponse(verify_code=verify_code)
+    return resp
+
+
+@app.get("/preregister")
+def preregister_verify(email_address: str, verify_code: str) -> Response:
+    """Verify a pre-registration email code."""
+    with sanitize_excs():
+        # Throws back exc if failed to verify
+        user_api.preregister_verify(
+            email_address=email_address,
+            verify_code=verify_code,
+        )
+    return success
+
+
 @app.post("/register")
 def register(register_request: api_models.RegisterRequest) -> Response:
     """Register a new user."""
     with sanitize_excs():
         # Don't expand with ** to avoid leaking request params
         user_api.register(
-            username=register_request.username,
+            email_address=register_request.email_address,
             password=register_request.password,
+            first_name=register_request.first_name,
+            last_name=register_request.last_name,
+            verify_code=register_request.verify_code,
         )
     return success
 
@@ -37,10 +65,11 @@ def login(form_data: OAuth2PasswordRequestForm = Depends()) -> api_models.LoginR
     with sanitize_excs():
         # Don't expand with ** to avoid leaking request params
         client_token = user_api.login(
-            username=form_data.username,
+            email_address=form_data.username,
             password=form_data.password,
         )
-    return api_models.LoginResponse(access_token=client_token)
+        resp = api_models.LoginResponse(access_token=client_token)
+    return resp
 
 
 @app.post("/login_json")
@@ -51,34 +80,55 @@ def login_json(
     with sanitize_excs():
         # Don't expand with ** to avoid leaking request params
         client_token = user_api.login(
-            username=login_request.username,
+            email_address=login_request.email_address,
             password=login_request.password,
         )
-    return api_models.LoginJsonResponse(client_token=client_token)
+        resp = api_models.LoginJsonResponse(client_token=client_token)
+    return resp
 
 
 @app.post("/logout")
 def logout(client_token: str = Depends(dependencies.get_token)) -> Response:
     """Log a currently logged-in user out."""
     with sanitize_excs():
-        user_api.logout(client_token)
+        user_api.logout(client_token=client_token)
     return success
 
 
 @app.post("/change_password")
 def change_password(
     change_password_request: api_models.ChangePasswordRequest,
-    username: str = Depends(dependencies.get_username),
+    email_address: str = Depends(dependencies.get_email_address),
 ) -> Response:
     """Change the currently authenticated user's password."""
     with sanitize_excs():
-        user_api.change_password(username, change_password_request.password)
+        user_api.change_password(
+            email_address=email_address,
+            password=change_password_request.password,
+        )
+    return success
+
+
+@app.post("/change_name")
+def change_name(
+    change_name_request: api_models.ChangeNameRequest,
+    email_address: str = Depends(dependencies.get_email_address),
+) -> Response:
+    """Change the currently authenticated user's name."""
+    with sanitize_excs():
+        user_api.change_name(
+            email_address=email_address,
+            first_name=change_name_request.first_name,
+            last_name=change_name_request.last_name,
+        )
     return success
 
 
 @app.post("/delete")
-def delete_user(username: str = Depends(dependencies.get_username)) -> Response:
+def delete_user(
+    email_address: str = Depends(dependencies.get_email_address),
+) -> Response:
     """Delete the currently logged-in user."""
     with sanitize_excs():
-        user_api.delete_user(username)
+        user_api.delete_user(email_address=email_address)
     return success

--- a/auth-api/container/auth_api/routers/main.py
+++ b/auth-api/container/auth_api/routers/main.py
@@ -67,6 +67,33 @@ def register(register_request: api_models.RegisterRequest) -> Response:
     return success
 
 
+@app.post("/request_reset_password")
+def request_reset_password(
+    request_reset_password_request: api_models.RequestResetPasswordRequest,
+) -> api_models.RequestResetPasswordResponse:
+    """Request a password reset."""
+    with sanitize_excs():
+        # Don't expand with ** to avoid leaking request params
+        reset_code = user_api.request_reset_password(
+            email_address=request_reset_password_request.email_address,
+        )
+        resp = api_models.RequestResetPasswordResponse(reset_code=reset_code)
+    return resp
+
+
+@app.post("/reset_password")
+def reset_password(reset_password_request: api_models.ResetPasswordRequest) -> Response:
+    """Reset a user's password."""
+    with sanitize_excs():
+        # Don't expand with ** to avoid leaking request params
+        user_api.reset_password(
+            email_address=reset_password_request.email_address,
+            new_password=reset_password_request.password,
+            reset_code=reset_password_request.reset_code,
+        )
+    return success
+
+
 @app.post("/login")
 def login(form_data: OAuth2PasswordRequestForm = Depends()) -> api_models.LoginResponse:
     """Log a user in."""

--- a/auth-api/container/auth_api/routers/main.py
+++ b/auth-api/container/auth_api/routers/main.py
@@ -13,6 +13,14 @@ app = FastAPI(root_path=config.EXPECTED_PREFIX)
 success = Response(status_code=status.HTTP_200_OK)
 
 
+@app.on_event("startup")
+async def app_startup() -> None:
+    """Verify config, start background tasks."""
+    # Validate env vars set
+    if any([var is None for var in config.REQUIRED_ENV_FOR_DEPLOY]):
+        raise Exception(f"Missing required env vars: {config.REQUIRED_ENV_FOR_DEPLOY}")
+
+
 @app.get("/ping", response_class=PlainTextResponse)
 def ping() -> str:
     """Ping pong."""

--- a/auth-api/container/auth_api/services/user_api/__init__.py
+++ b/auth-api/container/auth_api/services/user_api/__init__.py
@@ -8,6 +8,8 @@ from auth_api.services.user_api.client import (
     logout,
     preregister,
     preregister_verify,
+    request_reset_password,
+    reset_password,
 )
 
 __all__ = [
@@ -20,4 +22,6 @@ __all__ = [
     "logout",
     "preregister",
     "preregister_verify",
+    "request_reset_password",
+    "reset_password",
 ]

--- a/auth-api/container/auth_api/services/user_api/__init__.py
+++ b/auth-api/container/auth_api/services/user_api/__init__.py
@@ -1,17 +1,23 @@
 from auth_api.services.user_api.client import (
-    register,
+    change_name,
     change_password,
     delete_user,
+    email_address_from_token,
+    register,
     login,
     logout,
-    username_from_token,
+    preregister,
+    preregister_verify,
 )
 
 __all__ = [
-    "register",
+    "change_name",
     "change_password",
     "delete_user",
+    "email_address_from_token",
+    "register",
     "login",
     "logout",
-    "username_from_token",
+    "preregister",
+    "preregister_verify",
 ]

--- a/auth-api/container/auth_api/services/user_api/client.py
+++ b/auth-api/container/auth_api/services/user_api/client.py
@@ -63,6 +63,27 @@ def delete_user(email_address: str) -> None:
     _request("DELETE", "/users", params=params)
 
 
+def request_reset_password(email_address: str) -> Optional[str]:
+    """Request a password reset."""
+    body = {
+        "email_address": email_address,
+    }
+    resp = _request_shaped(
+        models.RequestPasswordResetResponse, "POST", "/password_resets", body
+    )
+    return resp.reset_code  # Will be None in prod, but actual code in testing / dev
+
+
+def reset_password(email_address: str, new_password: str, reset_code: str) -> None:
+    """Attempt to reset a password."""
+    body = {
+        "email_address": email_address,
+        "password": new_password,
+        "reset_code": reset_code,
+    }
+    _request("POST", "/users/reset_password", body)
+
+
 def login(email_address: str, password: str) -> str:
     """Log a user in, return client_token if success."""
     body = {

--- a/auth-api/container/auth_api/services/user_api/client.py
+++ b/auth-api/container/auth_api/services/user_api/client.py
@@ -1,36 +1,75 @@
+from typing import Optional
+
 from auth_api.services.user_api import models
 from auth_api.services.user_api.utils import _request, _request_shaped
 
 
-def register(username: str, password: str) -> None:
+def preregister(email_address: str) -> Optional[str]:
+    """Pre-register a new user, submitting their email for verification."""
+    body = {
+        "email_address": email_address,
+    }
+    resp = _request_shaped(models.PreRegisterResponse, "POST", "/pre_users", body)
+    return resp.verify_code  # Will be None in prod, but actual code in testing / dev
+
+
+def preregister_verify(email_address: str, verify_code: str) -> None:
+    """Check the email verify code, throws relevant exc if bad."""
+    body = {
+        "email_address": email_address,
+        "verify_code": verify_code,
+    }
+    _request("POST", "/pre_users/verify", body)
+
+
+def register(
+    email_address: str, password: str, first_name: str, last_name: str, verify_code: str
+) -> None:
     """Register a new user."""
     body = {
+        "email_address": email_address,
         "password": password,
+        "first_name": first_name,
+        "last_name": last_name,
+        "verify_code": verify_code,
     }
-    _request("POST", f"/users/{username}", body)
+    _request("POST", "/users", body)
 
 
-def change_password(username: str, password: str) -> None:
+def change_password(email_address: str, password: str) -> None:
     """Change a user's password."""
     body = {
+        "email_address": email_address,
         "password": password,
     }
-    _request("PUT", f"/users/{username}", body)
+    _request("PUT", "/users", body)
 
 
-def delete_user(username: str) -> None:
+def change_name(email_address: str, first_name: str, last_name: str) -> None:
+    """Change a user's name."""
+    body = {
+        "email_address": email_address,
+        "first_name": first_name,
+        "last_name": last_name,
+    }
+    _request("PUT", "/users", body)
+
+
+def delete_user(email_address: str) -> None:
     """Delete a user account."""
-    _request("DELETE", f"/users/{username}")
+    body = {
+        "email_address": email_address,
+    }
+    _request("DELETE", "/users", body)
 
 
-def login(username: str, password: str) -> str:
+def login(email_address: str, password: str) -> str:
     """Log a user in, return client_token if success."""
     body = {
+        "email_address": email_address,
         "password": password,
     }
-    resp = _request_shaped(
-        models.LoginResponse, "POST", f"/users/{username}/login", body
-    )
+    resp = _request_shaped(models.LoginResponse, "POST", "/users/login", body)
     return resp.client_token
 
 
@@ -39,7 +78,7 @@ def logout(client_token: str) -> None:
     _request("DELETE", f"/tokens/{client_token}")
 
 
-def username_from_token(client_token: str) -> str:
-    """Get the username associated with this token."""
+def email_address_from_token(client_token: str) -> str:
+    """Get the email address associated with this token."""
     resp = _request_shaped(models.TokenDataResponse, "GET", f"/tokens/{client_token}")
-    return resp.username
+    return resp.email_address

--- a/auth-api/container/auth_api/services/user_api/client.py
+++ b/auth-api/container/auth_api/services/user_api/client.py
@@ -57,10 +57,10 @@ def change_name(email_address: str, first_name: str, last_name: str) -> None:
 
 def delete_user(email_address: str) -> None:
     """Delete a user account."""
-    body = {
+    params = {
         "email_address": email_address,
     }
-    _request("DELETE", "/users", body)
+    _request("DELETE", "/users", params=params)
 
 
 def login(email_address: str, password: str) -> str:

--- a/auth-api/container/auth_api/services/user_api/models.py
+++ b/auth-api/container/auth_api/services/user_api/models.py
@@ -11,5 +11,9 @@ class PreRegisterResponse(BaseModel):
     verify_code: Optional[str] = None
 
 
+class RequestPasswordResetResponse(BaseModel):
+    reset_code: Optional[str] = None
+
+
 class TokenDataResponse(BaseModel):
     email_address: str

--- a/auth-api/container/auth_api/services/user_api/models.py
+++ b/auth-api/container/auth_api/services/user_api/models.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 
@@ -5,5 +7,9 @@ class LoginResponse(BaseModel):
     client_token: str
 
 
+class PreRegisterResponse(BaseModel):
+    verify_code: Optional[str] = None
+
+
 class TokenDataResponse(BaseModel):
-    username: str
+    email_address: str

--- a/auth-api/container/auth_api/services/user_api/utils.py
+++ b/auth-api/container/auth_api/services/user_api/utils.py
@@ -59,14 +59,16 @@ def _request(method: str, path: str, body: Any = None, params: Any = None) -> An
         raise Exception(f"Unexpected response {resp.status_code} - {resp.text}")
 
 
-def _request_shaped(output_obj: Type[T], method: str, path: str, body: Any = None) -> T:
+def _request_shaped(
+    output_obj: Type[T], method: str, path: str, body: Any = None, params: Any = None
+) -> T:
     """Request to user-api, shape the output object."""
     # Ensure output_obj is valid
     if not hasattr(output_obj, "parse_obj"):
         raise Exception(f"Cannot parse into bad type '{type(output_obj)}'")
 
     # Get response
-    resp_raw = _request(method=method, path=path, body=body)
+    resp_raw = _request(method=method, path=path, body=body, params=params)
 
     # Parse object
     # Let parsing exceptions propagate

--- a/auth-api/container/auth_api/services/user_api/utils.py
+++ b/auth-api/container/auth_api/services/user_api/utils.py
@@ -24,7 +24,7 @@ def _decode_json_safe(resp: requests.Response) -> Any:
         raise InternalError(f"Failed to parse JSON for '{str(e)}' - {resp.text}")
 
 
-def _request(method: str, path: str, body: Any = None) -> Any:
+def _request(method: str, path: str, body: Any = None, params: Any = None) -> Any:
     """Make a request to the user-api, handle bad status codes.
 
     This doesn't need headers, query string params, etc bc user-api currently doesn't
@@ -38,10 +38,7 @@ def _request(method: str, path: str, body: Any = None) -> Any:
 
     # Make the request
     # Let exceptions propagate as unhandled
-    if body is not None:
-        resp = requests.request(method, url, json=body)
-    else:
-        resp = requests.request(method, url)
+    resp = requests.request(method, url, json=body, params=params)
 
     # If 200, pass result up
     if resp.status_code == 200:

--- a/auth-api/container/auth_api/services/user_api/utils.py
+++ b/auth-api/container/auth_api/services/user_api/utils.py
@@ -30,6 +30,10 @@ def _request(method: str, path: str, body: Any = None, params: Any = None) -> An
     This doesn't need headers, query string params, etc bc user-api currently doesn't
     have any endpoints making use of those.
     """
+    # Backstop to check user api url is actually set
+    if USER_API_URL is None:
+        raise Exception("Missing USER_API_URL env var, should have been checked")
+
     # Prepare args
     if path and path[0] != "/":
         print("Path '{path}' doesn't have leading '/'")  # TODO replace with log warning

--- a/auth-api/container/garden.yaml
+++ b/auth-api/container/garden.yaml
@@ -16,5 +16,3 @@ tests:
     disabled: ${!(var.testsEnabledEnvs contains environment.name)}
     command: ["pytest"]
     args: ["-v", "tests/unit"]
-    env:
-      TEST_MODE: "true"

--- a/auth-api/container/tests/integ/test_auth.py
+++ b/auth-api/container/tests/integ/test_auth.py
@@ -1,5 +1,5 @@
 import random
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 from oauthlib.oauth2 import LegacyApplicationClient
 import pytest
@@ -20,29 +20,70 @@ def _random_alphanum(length=16) -> str:
     return "".join(random.choice(chars) for i in range(length))
 
 
-def _register_random() -> Optional[Dict[str, str]]:
-    """Register a random user, return username and password if successful."""
+def _random_email() -> str:
+    """Return a random email address."""
+    user_chars = "abcdefghijklmnopqrstuvwxyz0123456789_.+-"
+    user = "".join(random.choice(user_chars) for i in range(12))
+    domain = ".".join(
+        [
+            _random_alphanum(length=random.randint(2, 6))
+            for i in range(random.randint(2, 4))
+        ]
+    )
+    return f"{user}@{domain}"
+
+
+def _register_random() -> Optional[Tuple[str, str]]:
+    """Register a random user, return email address and password if successful."""
     # Generate a user we want
-    desired_user = {
-        "username": _random_alphanum(),
-        "password": _random_alphanum(),
+    email = _random_email()
+    password = _random_alphanum()
+
+    # Preregister the user
+    body = {"email_address": email}
+    resp = requests.post(f"{BASE_URL}/preregister", json=body)
+    if resp.status_code != 200:
+        print(f"Failed to pre-register, maybe expected - {resp.text}")
+        return None
+
+    # When email disabled, verify code passed directly back from pre-register
+    verify_code = resp.json().get("verify_code")
+
+    if verify_code in ["", None]:
+        raise Exception("Received blank verify code, may have email mistakenly enabled")
+
+    # Verify the code
+    query_params = {
+        "email_address": email,
+        "verify_code": verify_code,
     }
+    resp = requests.get(f"{BASE_URL}/preregister", params=query_params)
+    if resp.status_code != 200:
+        print(f"Failed to verify code, maybe expected - {resp.text}")
+        return None
 
     # Register the user
-    resp = requests.post(f"{BASE_URL}/register", json=desired_user)
+    body = {
+        "email_address": email,
+        "password": password,
+        "first_name": "Johnny",
+        "last_name": "Peter-Schmidt",
+        "verify_code": verify_code,
+    }
+    resp = requests.post(f"{BASE_URL}/register", json=body)
     if resp.status_code != 200:
         print(f"Failed to register, maybe expected - {resp.text}")
 
-    return desired_user
+    return email, password
 
 
-def _login_oauth2(username: str, password: str) -> Optional[Dict[str, str]]:
+def _login_oauth2(email_address: str, password: str) -> Optional[Dict[str, str]]:
     """Log a user in, return Auth header if successful."""
     try:
         oauth = OAuth2Session(client=LegacyApplicationClient(client_id=""))
         token = oauth.fetch_token(
             token_url=f"{BASE_URL}/login",
-            username=username,
+            username=email_address,
             password=password,
             client_id="",
             client_secret="",
@@ -55,10 +96,11 @@ def _login_oauth2(username: str, password: str) -> Optional[Dict[str, str]]:
         return None
 
 
-def _login_json(username: str, password: str) -> Optional[Dict[str, str]]:
+def _login_json(email_address: str, password: str) -> Optional[Dict[str, str]]:
     """Log a user in, return Auth header if successful."""
     resp = requests.post(
-        f"{BASE_URL}/login_json", json={"username": username, "password": password}
+        f"{BASE_URL}/login_json",
+        json={"email_address": email_address, "password": password},
     )
     if resp.status_code != 200:
         print(f"Failed to log in, maybe expected - {resp.text}")
@@ -72,9 +114,10 @@ def test_register_login_logout(auth_method):
     # Register a random user
     login_data = _register_random()
     assert login_data is not None, "Failed to register"
+    email, password = login_data
 
     # Log the user in
-    auth_header = auth_method(**login_data)
+    auth_header = auth_method(email, password)
     assert auth_header is not None, "Failed to log in"
 
     # Log the user out
@@ -91,9 +134,10 @@ def test_change_password(auth_method):
     """Test that a user can have their password changed."""
     login_data = _register_random()
     assert login_data is not None, "Failed to register"
+    email, password = login_data
 
     # Log the user in
-    auth_header = auth_method(**login_data)
+    auth_header = auth_method(email, password)
     assert auth_header is not None, "Failed to log in"
 
     # Change the password
@@ -114,12 +158,12 @@ def test_change_password(auth_method):
     assert resp.status_code == 401, "Token should be invalid"
 
     # Ensure old password doesn't work
-    should_fail = auth_method(**login_data)
+    should_fail = auth_method(email, password)
     assert should_fail is None, "Old password worked when it shouldn't"
 
     # Ensure new password works
-    login_data["password"] = new_password
-    auth_header = auth_method(**login_data)
+    password = new_password
+    auth_header = auth_method(email, password)
     assert auth_header is not None, "Failed to log in with new password"
 
     # Ensure log out works
@@ -132,9 +176,10 @@ def test_delete_user(auth_method):
     """Test that a user can be deleted."""
     login_data = _register_random()
     assert login_data is not None, "Failed to register"
+    email, password = login_data
 
     # Log the user in
-    auth_header = auth_method(**login_data)
+    auth_header = auth_method(email, password)
     assert auth_header is not None, "Failed to log in"
 
     # Delete the user
@@ -146,5 +191,5 @@ def test_delete_user(auth_method):
     assert resp.status_code == 401, "Session shouldn't exist after user delete"
 
     # Ensure re-login fails
-    auth_header = auth_method(**login_data)
+    auth_header = auth_method(email, password)
     assert auth_header is None, "Logged in to deleted user - uh oh"

--- a/scripts/cluster-init/setup-ingress-secret.sh
+++ b/scripts/cluster-init/setup-ingress-secret.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Set up an ingress secret in a cluster namespace
+# Set up an ingress certificate secret in a cluster namespace
 # Expects env vars set:
 #   KUBE_NS - kubernetes namespace to get the secret
 #   CRT_FILE - path to ingress cert file

--- a/scripts/cluster-init/setup-sendgrid-secret.sh
+++ b/scripts/cluster-init/setup-sendgrid-secret.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Set up a sendgrid api key secret in a cluster namespace
+# Expects env vars set:
+#   KUBE_NS - kubernetes namespace to get the secret
+#   SENDGRID_KEY - sendgrid api key
+# Expects to be authenticated to a kube cluster
+
+set -e
+
+# Check if env vars set
+if [[ -z "${KUBE_NS}" ]]
+then
+    echo "KUBE_NS env var is not set"
+    exit 1
+fi
+if [[ -z "${SENDGRID_KEY}" ]]
+then
+    echo "SENDGRID_KEY env var is not set"
+    exit 1
+fi
+
+# Validate connected to kube cluster
+kubectl auth can-i get pod
+
+# Create sendgrid secret
+kubectl create namespace "${KUBE_NS}" || true
+kubectl delete secret sendgrid --namespace "${KUBE_NS}" || true
+kubectl create secret generic sendgrid \
+    --namespace "${KUBE_NS}" --from-literal="sendgridKey=${SENDGRID_KEY}"

--- a/user-api/CODE.md
+++ b/user-api/CODE.md
@@ -11,15 +11,16 @@ This is pretty simple, and most of the base migrations code should never need to
 * [template.py](container/migrations/template.py) - A template that's copied into the migrations folder when you run `create_migration.sh`.
 * [migrations/\*](container/migrations/migrations) - Where migrations are written.
 
-For normal development purposes, you should only ever have to run `bash user-api/container/create_migration.sh <migration name>` (from the repository root) and develop in the blank migration file.
+For normal development purposes, you should only ever have to run `bash create_migration.sh <migration name>` (from the `user-api/container` directory) and develop in the blank migration file.
 
 
 ## user_api
 
-There are three layers to user_api, for separation of concerns. These layers correspond to three subfolders:
+There are three layers to user_api, for separation of concerns. These layers correspond to four subfolders:
 * [routers](container/user_api/routers) - The highest layer, defining endpoint object shapes and basic calls into the internal layer. This layer should contain little to no business logic. Most of the meat here is reshaping objects from the interface to internal functions, doing validation, and wrangling FastAPI dependencies. Most of these endpoints should use the `sanitize_excs` context manager (demonstrated in [routers/users.py](container/user_api/routers/users.py)) for security and client-friendliness.
-* [internal](container/user_api/internal) - The middle layer, containing practically all of the business logic. This layer is called from routers, and usually calls down to daos (to access the database) or services (to access external services) (future) to accomplish its goals. It should handle any anticipated exceptions and re-raise them as `ClientError`s if the user is at fault. `InternalError`s raised by lower layers can be allowed to propagate upwards. This layer should never create / use database cursors, but is expected to create database connections which are passed to DAO calls, as transactions are logically attached to business logic.
-* [daos](container/user_api/daos) - The lowest layer. This is a faily structured layer, where each file corresponds to a similarly-named database table. Each file contains a pydantic model, which defines the table columns (field order and types MUST match database). Each model object also defines various methods / classmethods for accomplishing its goals. These methods should receive a database connection and create a database cursor, as database transactions are above the logical responsibility of the DAO objects. These objects should also catch any anticipated exceptions and re-raise as descriptive `InternalError`s.
+* [internal](container/user_api/internal) - The middle layer, containing practically all of the business logic. This layer is called from routers, and usually calls down to daos (to access the database) or services (to access external services) to accomplish its goals. It should handle any anticipated exceptions and re-raise them as `ClientError`s if the user is at fault. `InternalError`s raised by lower layers can be allowed to propagate upwards. This layer should never create / use database cursors, but is expected to create database connections which are passed to DAO calls, as transactions are logically attached to business logic.
+* [daos](container/user_api/daos) - The first part of the lowest layer. This is a faily structured layer, where each file corresponds to a similarly-named database table. Each file contains a pydantic model, which defines the table columns (field order and types MUST match database). Each model object also defines various methods / classmethods for accomplishing its goals. These methods should receive a database connection and create a database cursor, as database transactions are above the logical responsibility of the DAO objects. These objects should also catch any anticipated exceptions and re-raise as descriptive `InternalError`s.
+* [services](container/user_api/services) - The second part of the lowest layer. This layer defines interaction with external APIs. Currently this is only Sendgrid's API, used for sending emails.
 
 
 ## tests
@@ -28,3 +29,9 @@ Three kinds of tests are defined in files / folders here:
 * [lint](container/tests/lint.sh) - Linting, specifically mypy, black, and flake8 for python and shellcheck for bash.
 * [unit](container/tests/unit) - Unit tests for any python stuff here. Should call specific functions, mocking dependencies as needed.
 * [integration](container/tests/integ) - Integration tests. Responsible for the integration between the API and its database, and accordingly operate by making HTTP calls to the API REST endpoints and evaluating the responses.
+
+
+## stubs
+
+These are type stubs for python dependencies without type hinting, allowing us to use `mypy --strict`. These can be a bit lenient for functions we don't often call, but overall should match the library being stubbed as accurately as possible. Currently stubbed libraries are:
+* [sendgrid](container/stubs/sendgrid) - Sendgrid email API.

--- a/user-api/README.md
+++ b/user-api/README.md
@@ -14,6 +14,7 @@ The [container](container) folder contains the source code for the python api. T
 * [user_api](container/user_api) Is the API itself, accessed with the command `uvicorn <args> user_api.routers.main:app`. Code structure docs at [CODE.md](CODE.md)
 * [migrations](container/migrations) Is the source code for database migrations, accessed with the command `python3 -m migrations.entrypoint`. Create new migrations with `bash user-api/container/create_migration.sh <migration name>`, run from repository root.
 * [tests](container/tests) Has the source for linting, unit tests, and integration tests.
+* [stubs](container/stubs) Has type stubs for python dependencies without their own type hinting.
 
 The [helm](helm) folder contains the helm chart for user_api and the subchart for the database:
 * [user-api](helm/user-api) Is the chart for the API deployment itself.

--- a/user-api/container/Dockerfile
+++ b/user-api/container/Dockerfile
@@ -33,6 +33,7 @@ ENV PYTHONPATH=$PYTHONPATH:/src
 
 COPY user_api /src/user_api
 COPY migrations /src/migrations
+COPY stubs /src/stubs
 COPY tests /src/tests
 COPY create_migration.sh src/create_migration.sh
 

--- a/user-api/container/create_migration.sh
+++ b/user-api/container/create_migration.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Expects to be run from code root (.../container in repo, /src in container)
 
 # Expects 1 argument: migration name
 
@@ -15,10 +16,10 @@ fi
 
 c_time=$(date +"%s")
 filename="m_${c_time}_$1.py"
-fullpath="user-api/container/migrations/migrations/$filename"
+fullpath="migrations/migrations/$filename"
 echo "Creating migration $filename"
 
-cp user-api/container/migrations/template.py "$fullpath"
+cp migrations/template.py "$fullpath"
 
 echo "Written to $fullpath"
 

--- a/user-api/container/garden.yaml
+++ b/user-api/container/garden.yaml
@@ -16,5 +16,3 @@ tests:
     disabled: ${!(var.testsEnabledEnvs contains environment.name)}
     command: ["pytest"]
     args: ["-v", "tests/unit"]
-    env:
-      TEST_MODE: "true"

--- a/user-api/container/migrations/migrations/m_1650938565_initial.py
+++ b/user-api/container/migrations/migrations/m_1650938565_initial.py
@@ -22,7 +22,6 @@ class Migration(BaseMigration):
                         created_time timestamp NOT NULL,
                         failed_attempts integer
                     );
-                    CREATE INDEX ON pre_users (verify_code);
                     CREATE TABLE users (
                         user_id uuid PRIMARY KEY,
                         email_address varchar(320) UNIQUE NOT NULL,

--- a/user-api/container/migrations/migrations/m_1650938565_initial.py
+++ b/user-api/container/migrations/migrations/m_1650938565_initial.py
@@ -16,10 +16,20 @@ class Migration(BaseMigration):
             # Create tables
             await cur.execute(
                 """
+                    CREATE TABLE pre_users (
+                        email_address varchar(320) UNIQUE NOT NULL,
+                        verify_code varchar(16) NOT NULL,
+                        created_time timestamp NOT NULL,
+                        failed_attempts integer
+                    );
+                    CREATE INDEX ON pre_users (verify_code);
                     CREATE TABLE users (
                         user_id uuid PRIMARY KEY,
-                        username varchar(32) UNIQUE NOT NULL,
-                        password_hash varchar(60) NOT NULL
+                        email_address varchar(320) UNIQUE NOT NULL,
+                        password_hash varchar(60) NOT NULL,
+                        first_name varchar(32) NOT NULL,
+                        last_name varchar(32) NOT NULL,
+                        created_time timestamp NOT NULL
                     );
                     CREATE TABLE sessions (
                         session_id uuid PRIMARY KEY,

--- a/user-api/container/migrations/migrations/m_1657942956_password_reset.py
+++ b/user-api/container/migrations/migrations/m_1657942956_password_reset.py
@@ -1,0 +1,37 @@
+"""A single migration to run."""
+
+from typing import Any
+
+from psycopg import AsyncConnection
+
+from migrations.migration import BaseMigration
+
+
+class Migration(BaseMigration):
+    """A base migration."""
+
+    async def upgrade(self, conn: AsyncConnection[Any]) -> None:
+        """Run the migration."""
+        async with conn.cursor() as cur:
+            # Create tables
+            await cur.execute(
+                """
+                    CREATE TABLE password_resets (
+                        reset_code uuid PRIMARY KEY,
+                        user_id uuid UNIQUE REFERENCES users ON DELETE CASCADE,
+                        created_time timestamp NOT NULL
+                    );
+                """,
+            )
+
+    async def was_successful(self, conn: AsyncConnection[Any]) -> bool:
+        """Check if the migration was successful.
+
+        Function may return False to indicate generic error. You are encouraged to raise
+        a descriptive exception inside the function instead. Both of these behaviors are
+        handled in the runner.
+
+        This function should _always_ return False / raise Exception if the migration
+        did not run at all.
+        """
+        return True

--- a/user-api/container/requirements.txt
+++ b/user-api/container/requirements.txt
@@ -4,6 +4,7 @@ fastapi==0.78.0
 orjson==3.7.7
 psycopg[binary]==3.0.15
 python-multipart==0.0.5
+sendgrid==6.9.7
 uvicorn[standard]==0.18.2
 
 # Test / lint requirements

--- a/user-api/container/stubs/sendgrid/__init__.pyi
+++ b/user-api/container/stubs/sendgrid/__init__.pyi
@@ -1,0 +1,5 @@
+from .sendgrid import SendGridAPIClient
+
+__all__ = [
+    "SendGridAPIClient"
+]

--- a/user-api/container/stubs/sendgrid/helpers/mail/__init__.pyi
+++ b/user-api/container/stubs/sendgrid/helpers/mail/__init__.pyi
@@ -1,0 +1,9 @@
+from .mail import Mail
+from .mail_settings import MailSettings
+from .sandbox_mode import SandBoxMode
+
+__all__ = [
+    "Mail",
+    "MailSettings",
+    "SandBoxMode",
+]

--- a/user-api/container/stubs/sendgrid/helpers/mail/mail.pyi
+++ b/user-api/container/stubs/sendgrid/helpers/mail/mail.pyi
@@ -1,0 +1,19 @@
+from typing import Any, Dict, List, Optional, Union
+
+from .mail_settings import MailSettings
+
+
+class Mail(object):
+    mail_settings: MailSettings
+
+    def __init__(
+        self,
+        from_email: Optional[str] = ...,
+        to_emails: Union[List[str], str] = ...,
+        subject: str = ...,
+        plain_text_content: Optional[str] = ...,
+        html_content: Optional[str] = ...,
+        amp_html_content: Optional[str] = ...,
+        global_substitutions: Optional[Dict[Any, Any]] = ...,
+        is_multiple: bool = ...,
+    ) -> None: ...

--- a/user-api/container/stubs/sendgrid/helpers/mail/mail_settings.pyi
+++ b/user-api/container/stubs/sendgrid/helpers/mail/mail_settings.pyi
@@ -1,0 +1,17 @@
+from typing import Any, Optional
+
+from .sandbox_mode import SandBoxMode
+
+
+class MailSettings(object):
+    def __init__(
+        self,
+        bcc_settings: Any = ...,
+        bypass_bounce_management: Any = ...,
+        bypass_list_management: Any = ...,
+        bypass_spam_management: Any = ...,
+        bypass_unsubscribe_management: Any = ...,
+        footer_settings: Any = ...,
+        sandbox_mode: Optional[SandBoxMode] = ...,
+        spam_check: Any = ...,
+    ) -> None: ...

--- a/user-api/container/stubs/sendgrid/helpers/mail/sandbox_mode.pyi
+++ b/user-api/container/stubs/sendgrid/helpers/mail/sandbox_mode.pyi
@@ -1,0 +1,8 @@
+from typing import Optional
+
+
+class SandBoxMode(object):
+    def __init__(
+        self,
+        enable: Optional[bool] = ...,
+    ) -> None: ...

--- a/user-api/container/stubs/sendgrid/sendgrid.pyi
+++ b/user-api/container/stubs/sendgrid/sendgrid.pyi
@@ -1,0 +1,21 @@
+from typing import Any, Dict, Optional, Protocol, Union
+
+from .helpers.mail import Mail
+
+
+class _MessageResponse(Protocol):
+    status_code: int
+
+
+class SendGridAPIClient(object):
+    def __init__(
+        self,
+        api_key: str,
+        host: str = ...,
+        impersonate_subuser: Optional[str] = ...,
+    ) -> None: ...
+
+    def send(
+        self,
+        message: Union[Dict[Any, Any], Mail],
+    ) -> _MessageResponse: ...

--- a/user-api/container/tests/integ/test_users.py
+++ b/user-api/container/tests/integ/test_users.py
@@ -169,7 +169,7 @@ def test_delete_user():
     body = {
         "email_address": email,
     }
-    resp = requests.delete(f"{BASE_URL}/users", json=body)
+    resp = requests.delete(f"{BASE_URL}/users", params=body)
     _assert_good_resp(resp)
 
     # Ensure log out fails

--- a/user-api/container/tests/integ/test_users.py
+++ b/user-api/container/tests/integ/test_users.py
@@ -387,7 +387,7 @@ def test_password_reset_fails_multiuser():
     body = {
         "email_address": email_1,
         "password": new_password,
-        "reset_code": reset_code_2
+        "reset_code": reset_code_2,
     }
     resp = requests.post(f"{BASE_URL}/users/reset_password", json=body)
     assert resp.status_code != 200
@@ -398,7 +398,7 @@ def test_password_reset_fails_multiuser():
     body = {
         "email_address": email_2,
         "password": new_password,
-        "reset_code": reset_code_1
+        "reset_code": reset_code_1,
     }
     resp = requests.post(f"{BASE_URL}/users/reset_password", json=body)
     assert resp.status_code != 200

--- a/user-api/container/tests/integ/test_users.py
+++ b/user-api/container/tests/integ/test_users.py
@@ -41,7 +41,7 @@ def _random_email() -> str:
 
 
 def _register_random() -> Optional[Tuple[str, str]]:
-    """Register a random user, return username and password if successful."""
+    """Register a random user, return email and password if successful."""
     # Generate a user we want
     email = _random_email()
     password = _random_alphanum()
@@ -193,7 +193,7 @@ def test_get_token():
 
     # Get the token's associated email
     resp = requests.get(f"{BASE_URL}/tokens/{client_token}")
-    assert resp.status_code == 200, "Failed to find username for token"
+    assert resp.status_code == 200, "Failed to find email for token"
     assert resp.json()["email_address"] == email
 
 

--- a/user-api/container/tests/integ/test_users.py
+++ b/user-api/container/tests/integ/test_users.py
@@ -18,27 +18,80 @@ def _random_alphanum(length=16) -> str:
     return "".join(random.choice(chars) for i in range(length))
 
 
+def _random_digits_not(length: int, not_match: str):
+    """Get a given number of random digits, not matching the provided."""
+    output = "".join([str(random.randint(0, 9)) for i in range(length)])
+    while output == not_match:
+        print("Collision!")
+        output = "".join([str(random.randint(0, 9)) for i in range(length)])
+    return output
+
+
+def _random_email() -> str:
+    """Return a random email address."""
+    user_chars = "abcdefghijklmnopqrstuvwxyz0123456789_.+-"
+    user = "".join(random.choice(user_chars) for i in range(12))
+    domain = ".".join(
+        [
+            _random_alphanum(length=random.randint(2, 6))
+            for i in range(random.randint(2, 4))
+        ]
+    )
+    return f"{user}@{domain}"
+
+
 def _register_random() -> Optional[Tuple[str, str]]:
     """Register a random user, return username and password if successful."""
     # Generate a user we want
-    username = _random_alphanum()
+    email = _random_email()
     password = _random_alphanum()
 
+    # Pre-register the user
+    body = {"email_address": email}
+    resp = requests.post(f"{BASE_URL}/pre_users", json=body)
+    if resp.status_code != 200:
+        print(f"Failed to pre-register, maybe expected - {resp.text}")
+        return None
+
+    # When email disabled, verify code passed directly back from pre-register
+    verify_code = resp.json().get("verify_code")
+
+    if verify_code in ["", None]:
+        raise Exception("Received blank verify code, may have email mistakenly enabled")
+
+    # Verify the code
+    body = {
+        "email_address": email,
+        "verify_code": verify_code,
+    }
+    resp = requests.post(f"{BASE_URL}/pre_users/verify", json=body)
+    if resp.status_code != 200:
+        print(f"Failed to verify code, maybe expected - {resp.text}")
+        return None
+
     # Register the user
-    body = {"password": password}
-    resp = requests.post(f"{BASE_URL}/users/{username}", json=body)
+    body = {
+        "email_address": email,
+        "password": password,
+        "first_name": "Johnny",
+        "last_name": "Peter-Schmidt",
+        "verify_code": verify_code,
+    }
+    resp = requests.post(f"{BASE_URL}/users", json=body)
     if resp.status_code != 200:
         print(f"Failed to register, maybe expected - {resp.text}")
         return None
 
-    return username, password
+    return email, password
 
 
-def _login_json(username: str, password: str) -> Optional[Dict[str, str]]:
+def _login_json(email_address: str, password: str) -> Optional[Dict[str, str]]:
     """Log a user in, return client token if successful."""
-    resp = requests.post(
-        f"{BASE_URL}/users/{username}/login", json={"password": password}
-    )
+    body = {
+        "email_address": email_address,
+        "password": password,
+    }
+    resp = requests.post(f"{BASE_URL}/users/login", json=body)
     if resp.status_code != 200 or "client_token" not in resp.json():
         print(f"Failed to log in, maybe expected - {resp.text}")
         return None
@@ -50,10 +103,10 @@ def test_register_login_logout():
     # Register a random user
     login_data = _register_random()
     assert login_data is not None, "Failed to register"
-    username, password = login_data
+    email, password = login_data
 
     # Log the user in
-    client_token = _login_json(username, password)
+    client_token = _login_json(email, password)
     assert client_token is not None, "Failed to log in"
 
     # Log the user out
@@ -69,18 +122,16 @@ def test_change_password():
     """Test that a user can have their password changed."""
     login_data = _register_random()
     assert login_data is not None, "Failed to register"
-    username, password = login_data
+    email, password = login_data
 
     # Log the user in
-    client_token = _login_json(username, password)
+    client_token = _login_json(email, password)
     assert client_token is not None, "Failed to log in"
 
     # Change the password
     new_password = _random_alphanum()
-    resp = requests.put(
-        f"{BASE_URL}/users/{username}",
-        json={"password": new_password},
-    )
+    body = {"email_address": email, "password": new_password}
+    resp = requests.put(f"{BASE_URL}/users", json=body)
     _assert_good_resp(resp)
 
     # Log the user out
@@ -92,11 +143,11 @@ def test_change_password():
     assert resp.status_code != 200, "Token should be invalid"
 
     # Ensure old password doesn't work
-    should_fail = _login_json(username, password)
+    should_fail = _login_json(email, password)
     assert should_fail is None, "Old password worked when it shouldn't"
 
     # Ensure new password works
-    client_token = _login_json(username, new_password)
+    client_token = _login_json(email, new_password)
     assert client_token is not None, "Failed to log in with new password"
 
     # Ensure log out works
@@ -108,14 +159,17 @@ def test_delete_user():
     """Test that a user can be deleted."""
     login_data = _register_random()
     assert login_data is not None, "Failed to register"
-    username, password = login_data
+    email, password = login_data
 
     # Log the user in
-    client_token = _login_json(username, password)
+    client_token = _login_json(email, password)
     assert client_token is not None, "Failed to log in"
 
     # Delete the user
-    resp = requests.delete(f"{BASE_URL}/users/{username}")
+    body = {
+        "email_address": email,
+    }
+    resp = requests.delete(f"{BASE_URL}/users", json=body)
     _assert_good_resp(resp)
 
     # Ensure log out fails
@@ -123,7 +177,7 @@ def test_delete_user():
     assert resp.status_code != 200, "Session shouldn't exist after user delete"
 
     # Ensure re-login fails
-    client_token = _login_json(username, password)
+    client_token = _login_json(email, password)
     assert client_token is None, "Logged in to deleted user - uh oh"
 
 
@@ -131,13 +185,123 @@ def test_get_token():
     """Test that a token's associated user can be found."""
     login_data = _register_random()
     assert login_data is not None, "Failed to register"
-    username, password = login_data
+    email, password = login_data
 
     # Log the user in
-    client_token = _login_json(username, password)
+    client_token = _login_json(email, password)
     assert client_token is not None, "Failed to log in"
 
-    # Get the token's associated username
+    # Get the token's associated email
     resp = requests.get(f"{BASE_URL}/tokens/{client_token}")
     assert resp.status_code == 200, "Failed to find username for token"
-    assert resp.json()["username"] == username
+    assert resp.json()["email_address"] == email
+
+
+def _ensure_locked_out(email: str, verify_code: str):
+    # Ensure cannot send another email
+    body = {"email_address": email}
+    resp = requests.post(f"{BASE_URL}/pre_users", json=body)
+    assert resp.status_code != 200, "Expected failure after n mistakes"
+    assert "Maximum failed registrations" in resp.json()["detail"]
+
+    # Ensure cannot verify code
+    body = {
+        "email_address": email,
+        "verify_code": verify_code,
+    }
+    resp = requests.post(f"{BASE_URL}/pre_users/verify", json=body)
+    assert resp.status_code != 200, "Expected failure after n mistakes"
+    assert "Maximum failed registrations" in resp.json()["detail"]
+
+    # Ensure cannot register
+    body = {
+        "email_address": email,
+        "password": _random_alphanum(16),
+        "first_name": "Johnny",
+        "last_name": "Peter-Schmidt",
+        "verify_code": verify_code,
+    }
+    resp = requests.post(f"{BASE_URL}/users", json=body)
+    assert resp.status_code != 200, "Expected failure after n mistakes"
+    assert "Maximum failed registrations" in resp.json()["detail"]
+
+
+def test_pre_register_lockout():
+    """Test that sending too many verify emails leads to failure."""
+    email = _random_email()
+
+    # Pre-register the user enough times to exhaust allowed failures
+    for i in range(6):
+        body = {"email_address": email}
+        resp = requests.post(f"{BASE_URL}/pre_users", json=body)
+        assert resp.status_code == 200, "Expected first 6 attempts to pass"
+        verify_code = resp.json().get("verify_code")
+        if verify_code in ["", None]:
+            raise Exception(
+                "Received blank verify code, may have email mistakenly enabled"
+            )
+
+    # Ensure locked out
+    _ensure_locked_out(email, verify_code)
+
+
+def test_verify_lockout():
+    """Test that trying to verify too many codes leads to failure."""
+    email = _random_email()
+
+    # Pre-register the user
+    body = {"email_address": email}
+    resp = requests.post(f"{BASE_URL}/pre_users", json=body)
+    assert resp.status_code == 200, "Expected pre-register to pass"
+    verify_code = resp.json().get("verify_code")
+    if verify_code in ["", None]:
+        raise Exception("Received blank verify code, may have email mistakenly enabled")
+
+    # Verify the user enough times to exhaust allowed failures
+    for i in range(5):
+        body = {
+            "email_address": email,
+            "verify_code": _random_digits_not(6, verify_code),
+        }
+        resp = requests.post(f"{BASE_URL}/pre_users/verify", json=body)
+        assert resp.json()["detail"] == "Verification code invalid"
+
+    # Ensure locked out
+    _ensure_locked_out(email, verify_code)
+
+
+def test_register_lockout():
+    """Test that trying to register too many times leads to failure."""
+    email = _random_email()
+
+    # Pre-register the user
+    body = {"email_address": email}
+    resp = requests.post(f"{BASE_URL}/pre_users", json=body)
+    assert resp.status_code == 200, "Expected pre-register to pass"
+    verify_code = resp.json().get("verify_code")
+    if verify_code in ["", None]:
+        raise Exception("Received blank verify code, may have email mistakenly enabled")
+
+    # Verify the code
+    body = {
+        "email_address": email,
+        "verify_code": verify_code,
+    }
+    resp = requests.post(f"{BASE_URL}/pre_users/verify", json=body)
+    assert resp.status_code == 200
+
+    # Register the user enough times to exhaust allowed failures
+    for i in range(5):
+        body = {
+            "email_address": email,
+            "password": _random_alphanum(16),
+            "first_name": "Johnny",
+            "last_name": "Peter-Schmidt",
+            "verify_code": _random_digits_not(6, verify_code),
+        }
+        resp = requests.post(f"{BASE_URL}/users", json=body)
+        assert resp.status_code != 200
+        assert resp.json()["detail"] == "Verification code invalid"
+
+    # Ensure locked out
+    _ensure_locked_out(email, verify_code)

--- a/user-api/container/tests/lint.sh
+++ b/user-api/container/tests/lint.sh
@@ -3,6 +3,12 @@
 
 set -e
 
+export MYPYPATH=stubs
+
+# No black for stubs (formats .pyi files wrong)
+mypy stubs --strict
+flake8 --max-line-length=88 stubs
+
 mypy user_api --strict
 black --check --diff user_api
 flake8 --max-line-length=88 user_api

--- a/user-api/container/user_api/config.py
+++ b/user-api/container/user_api/config.py
@@ -7,6 +7,7 @@ DB_PASS = os.getenv("DB_PASS")
 DB_ADDRESS = os.getenv("DB_ADDRESS")
 DB_PORT = os.getenv("DB_PORT")
 DB_NAME = os.getenv("DB_NAME")
+SENDGRID_KEY = os.getenv("SENDGRID_KEY")
 
 
 # Env vars required for a full deployment, checked in app_startup

--- a/user-api/container/user_api/config.py
+++ b/user-api/container/user_api/config.py
@@ -1,6 +1,7 @@
 import os
 
 
+# Env var config
 EXPECTED_PREFIX = os.getenv("EXPECTED_PREFIX") or ""
 DB_USER = os.getenv("DB_USER")
 DB_PASS = os.getenv("DB_PASS")
@@ -22,4 +23,5 @@ REQUIRED_ENV_FOR_DEPLOY = [
     DB_NAME,
 ]
 
+# Computed config
 EMAIL_ENABLED = SENDGRID_KEY not in [None, ""]

--- a/user-api/container/user_api/config.py
+++ b/user-api/container/user_api/config.py
@@ -1,51 +1,19 @@
 import os
-from typing import Optional, TypeVar, Type
 
 
-T = TypeVar("T")
-
-TEST_MODE = os.getenv("TEST_MODE")
-
-
-def _get_env(name: str, required: bool = False) -> Optional[str]:
-    """Retrieve an environment variable.
-
-    Params:
-        name - the name of the environment variable
-        required - whether to err if the variable doesn't exist.
-
-    Returns: The env var's contents as a string
-    """
-    value = os.getenv(name)
-    if required and not value:
-        if TEST_MODE:
-            return ""
-        else:
-            raise Exception(f"Required env var not set: {name}")
-    return value
+EXPECTED_PREFIX = os.getenv("EXPECTED_PREFIX") or ""
+DB_USER = os.getenv("DB_USER")
+DB_PASS = os.getenv("DB_PASS")
+DB_ADDRESS = os.getenv("DB_ADDRESS")
+DB_PORT = os.getenv("DB_PORT")
+DB_NAME = os.getenv("DB_NAME")
 
 
-def _get_env_cast(name: str, cast: Type[T]) -> T:
-    """Retrieve a required environment variable and cast it.
-
-    Params:
-        name - the name of the environment variable
-        cast - a Callable & Type to pass the variable through
-
-    Returns: The env var's contents, cast as requested
-    """
-    value = _get_env(name, required=True)
-    try:
-        return cast(value)  # type: ignore
-    except ValueError as e:
-        raise Exception(
-            f"Cannot cast env var to type '{cast}' - {name}: {value} - {str(e)}"
-        )
-
-
-EXPECTED_PREFIX = _get_env("EXPECTED_PREFIX") or ""
-DB_USER = _get_env("DB_USER", required=True)
-DB_PASS = _get_env("DB_PASS", required=True)
-DB_ADDRESS = _get_env("DB_ADDRESS", required=True)
-DB_PORT = _get_env("DB_PORT", required=True)
-DB_NAME = _get_env("DB_NAME", required=True)
+# Env vars required for a full deployment, checked in app_startup
+REQUIRED_ENV_FOR_DEPLOY = [
+    DB_USER,
+    DB_PASS,
+    DB_ADDRESS,
+    DB_PORT,
+    DB_NAME,
+]

--- a/user-api/container/user_api/config.py
+++ b/user-api/container/user_api/config.py
@@ -9,6 +9,8 @@ DB_PORT = os.getenv("DB_PORT")
 DB_NAME = os.getenv("DB_NAME")
 SENDGRID_KEY = os.getenv("SENDGRID_KEY")
 EMAIL_FROM = os.getenv("EMAIL_FROM") or "Web Games <no-reply@games.levilutz.com>"
+ALLOWED_FAILED_VERIFICATIONS = int(os.getenv("ALLOWED_FAILED_VERIFICATIONS") or "5")
+VERIFY_CODE_LENGTH = int(os.getenv("VERIFY_CODE_LENGTH") or "6")
 
 
 # Env vars required for a full deployment, checked in app_startup
@@ -19,3 +21,5 @@ REQUIRED_ENV_FOR_DEPLOY = [
     DB_PORT,
     DB_NAME,
 ]
+
+EMAIL_ENABLED = SENDGRID_KEY not in [None, ""]

--- a/user-api/container/user_api/config.py
+++ b/user-api/container/user_api/config.py
@@ -8,6 +8,7 @@ DB_ADDRESS = os.getenv("DB_ADDRESS")
 DB_PORT = os.getenv("DB_PORT")
 DB_NAME = os.getenv("DB_NAME")
 SENDGRID_KEY = os.getenv("SENDGRID_KEY")
+EMAIL_FROM = os.getenv("EMAIL_FROM") or "Web Games <no-reply@games.levilutz.com>"
 
 
 # Env vars required for a full deployment, checked in app_startup

--- a/user-api/container/user_api/config.py
+++ b/user-api/container/user_api/config.py
@@ -23,5 +23,6 @@ REQUIRED_ENV_FOR_DEPLOY = [
     DB_NAME,
 ]
 
+
 # Computed config
 EMAIL_ENABLED = SENDGRID_KEY not in [None, ""]

--- a/user-api/container/user_api/daos/__init__.py
+++ b/user-api/container/user_api/daos/__init__.py
@@ -1,10 +1,12 @@
 from user_api.daos.database import AsyncConnection, get_db_connection
+from user_api.daos.pre_user import PreUser
 from user_api.daos.session import Session
 from user_api.daos.user import User
 
 __all__ = [
-    "get_db_connection",
     "AsyncConnection",
+    "PreUser",
     "Session",
     "User",
+    "get_db_connection",
 ]

--- a/user-api/container/user_api/daos/__init__.py
+++ b/user-api/container/user_api/daos/__init__.py
@@ -1,10 +1,12 @@
 from user_api.daos.database import AsyncConnection, get_db_connection
+from user_api.daos.password_reset import PasswordReset
 from user_api.daos.pre_user import PreUser
 from user_api.daos.session import Session
 from user_api.daos.user import User
 
 __all__ = [
     "AsyncConnection",
+    "PasswordReset",
     "PreUser",
     "Session",
     "User",

--- a/user-api/container/user_api/daos/database.py
+++ b/user-api/container/user_api/daos/database.py
@@ -10,6 +10,18 @@ AsyncConnection = psycopg.AsyncConnection[Any]
 
 async def get_db_connection() -> psycopg.AsyncConnection[Any]:
     """Get a new db connection."""
+    # Backstop to verify env vars again
+    req_vars = [
+        config.DB_USER,
+        config.DB_PASS,
+        config.DB_ADDRESS,
+        config.DB_PORT,
+        config.DB_NAME,
+    ]
+    if any([var is None for var in req_vars]):
+        raise Exception(f"Missing db env vars: {req_vars}")
+
+    # Create connection
     conn = await psycopg.AsyncConnection.connect(
         user=config.DB_USER,
         password=config.DB_PASS,

--- a/user-api/container/user_api/daos/password_reset.py
+++ b/user-api/container/user_api/daos/password_reset.py
@@ -1,0 +1,123 @@
+from __future__ import annotations  # Postponed annotation evaluation, remove once 3.11
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from psycopg.rows import class_row
+from pydantic import BaseModel, UUID4
+
+from user_api.daos.database import AsyncConnection
+from user_api.exceptions import InternalError
+
+
+PASSWORD_RESET_TTL_HOURS = 12
+
+
+class PasswordReset(BaseModel):
+    reset_code: UUID4
+    user_id: UUID4
+    created_time: datetime
+
+    async def create(self, conn: AsyncConnection) -> None:
+        """Create the current password_reset in the database."""
+        if await self.find_by_reset_code(conn, self.reset_code) is not None:
+            raise InternalError(
+                f"Cannot create PasswordReset - code {self.reset_code} already claimed"
+            )
+
+        if await self.find_by_user_id(conn, self.user_id) is not None:
+            raise InternalError(
+                f"Cannot create PasswordReset - user {self.user_id} already resetting"
+            )
+
+        async with conn.cursor() as cur:
+            # Clean up expired for this user_id if necessary
+            latest_valid = datetime.utcnow() - timedelta(hours=PASSWORD_RESET_TTL_HOURS)
+            await cur.execute(
+                "DELETE FROM password_resets WHERE user_id = %s AND created_time <= %s",
+                (self.user_id, latest_valid),
+            )
+
+            # Create the new password reset
+            await cur.execute(
+                "INSERT INTO password_resets VALUES (%s, %s, %s)",
+                (tuple(self.dict().values())),
+            )
+
+    async def delete(self, conn: AsyncConnection) -> None:
+        """Delete the current password reset from the database."""
+        await self.assert_exists(conn)
+
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "DELETE FROM password_resets WHERE reset_code = %s",
+                (self.reset_code,),
+            )
+
+    async def assert_exists(self, conn: AsyncConnection) -> None:
+        """Raise exception of the password reset doesn't exist."""
+        password_reset = await self.find_by_reset_code(conn, self.reset_code)
+        if password_reset is None:
+            raise InternalError(
+                "Password reset does not exist in db, should have been checked earlier"
+            )
+
+        # Complain on any differences from db
+        if (
+            self.reset_code != password_reset.reset_code
+            or self.user_id != password_reset.user_id
+            or self.created_time != password_reset.created_time
+        ):
+            raise InternalError(
+                f"PasswordReset deviation from db: {self} vs {password_reset}"
+            )
+
+    @classmethod
+    async def find_by_reset_code(
+        cls, conn: AsyncConnection, reset_code: UUID4
+    ) -> Optional[PasswordReset]:
+        """Find a password reset by code."""
+        async with conn.cursor(row_factory=class_row(PasswordReset)) as cur:
+            await cur.execute(
+                "SELECT * FROM password_resets WHERE reset_code = %s",
+                (reset_code,),
+            )
+            password_reset = await cur.fetchone()
+            if (
+                password_reset is None
+                or password_reset.expiry_time() < datetime.utcnow()
+            ):
+                return None
+            return password_reset
+
+    @classmethod
+    async def find_by_user_id(
+        cls, conn: AsyncConnection, user_id: UUID4
+    ) -> Optional[PasswordReset]:
+        """Find a password reset by code."""
+        async with conn.cursor(row_factory=class_row(PasswordReset)) as cur:
+            await cur.execute(
+                "SELECT * FROM password_resets WHERE user_id = %s",
+                (user_id,),
+            )
+            password_reset = await cur.fetchone()
+            if (
+                password_reset is None
+                or password_reset.expiry_time() < datetime.utcnow()
+            ):
+                return None
+            return password_reset
+
+    @classmethod
+    async def cleanup_expired(cls, conn: AsyncConnection) -> None:
+        """Clean up expired password resets."""
+        latest_valid = datetime.utcnow() - timedelta(hours=PASSWORD_RESET_TTL_HOURS)
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "DELETE FROM password_resets WHERE created_time <= %s",
+                (latest_valid,),
+            )
+
+    def expiry_time(self) -> datetime:
+        """Get the password reset's expiration time."""
+        return self.created_time + timedelta(hours=PASSWORD_RESET_TTL_HOURS)

--- a/user-api/container/user_api/daos/pre_user.py
+++ b/user-api/container/user_api/daos/pre_user.py
@@ -1,0 +1,130 @@
+from __future__ import annotations  # Postponed annotation evaluation, remove once 3.11
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from psycopg.rows import class_row
+from pydantic import BaseModel
+
+from user_api.daos.database import AsyncConnection
+from user_api.daos.utils import _verify_email_lowercase
+from user_api.exceptions import InternalError
+
+
+PREUSER_TTL_HOURS = 24
+
+
+class PreUser(BaseModel):
+    """A user that hasn't verified yet."""
+
+    email_address: str
+    verify_code: str
+    created_time: datetime
+    failed_attempts: int
+
+    async def create(self, conn: AsyncConnection) -> None:
+        """Create the current pre-user in the database."""
+        _verify_email_lowercase(self.email_address)
+
+        if await self.find_by_email_address(conn, self.email_address) is not None:
+            raise InternalError(
+                f"Cannot create PreUser - email {self.email_address} already exists"
+            )
+
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "INSERT INTO pre_users VALUES (%s, %s, %s, %s)",
+                tuple(self.dict().values()),
+            )
+
+    async def update_verify_code(self, conn: AsyncConnection, verify_code: str) -> None:
+        """Update the verification code."""
+        _verify_email_lowercase(self.email_address)
+
+        await self.assert_exists(conn)
+
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "UPDATE pre_users SET verify_code = %s WHERE email_address = %s",
+                (verify_code, self.email_address),
+            )
+
+        self.verify_code = verify_code
+
+    async def increment_failed_attempts(
+        self, conn: AsyncConnection, amount: int = 1
+    ) -> None:
+        """Increment the failed attempts by the given amount, defaulting to 1."""
+        _verify_email_lowercase(self.email_address)
+
+        await self.assert_exists(conn)
+
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "UPDATE pre_users SET failed_attempts = %s WHERE email_address = %s",
+                (self.failed_attempts + amount, self.email_address),
+            )
+
+        self.failed_attempts += amount
+
+    async def delete(self, conn: AsyncConnection) -> None:
+        """Delete the current pre-user from the database."""
+        _verify_email_lowercase(self.email_address)
+
+        await self.assert_exists(conn)
+
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "DELETE FROM pre_users WHERE email_address = %s",
+                (self.email_address,),
+            )
+
+    @classmethod
+    async def find_by_email_address(
+        cls, conn: AsyncConnection, email_address: str
+    ) -> Optional[PreUser]:
+        """Find a pre-user by email address."""
+        _verify_email_lowercase(email_address)
+
+        async with conn.cursor(row_factory=class_row(PreUser)) as cur:
+            await cur.execute(
+                "SELECT * FROM pre_users WHERE email_address = %s",
+                (email_address,),
+            )
+            pre_user = await cur.fetchone()
+            if pre_user is None or pre_user.expiry_time() < datetime.utcnow():
+                return None
+            return pre_user
+
+    async def assert_exists(self, conn: AsyncConnection) -> None:
+        """Raise exception if the email address doesn't exist."""
+        _verify_email_lowercase(self.email_address)
+
+        pre_user = await self.find_by_email_address(conn, self.email_address)
+        if pre_user is None:
+            raise InternalError(
+                "PreUser does not exist in db, should have been checked earlier"
+            )
+
+        # Complain on any differences from db
+        if (
+            self.email_address != pre_user.email_address
+            or self.verify_code != pre_user.verify_code
+            or self.created_time != pre_user.created_time
+            or self.failed_attempts != pre_user.failed_attempts
+        ):
+            raise InternalError(f"PreUser deviation from db: {self} vs {pre_user}")
+
+    @classmethod
+    async def cleanup_expired(cls, conn: AsyncConnection) -> None:
+        """Clean up expired pre-users."""
+        latest_valid = datetime.utcnow() - timedelta(hours=PREUSER_TTL_HOURS)
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "DELETE FROM pre_users WHERE created_time < %s",
+                (latest_valid,),
+            )
+
+    def expiry_time(self) -> datetime:
+        """Get the pre-user's expiry time."""
+        return self.created_time + timedelta(hours=PREUSER_TTL_HOURS)

--- a/user-api/container/user_api/daos/session.py
+++ b/user-api/container/user_api/daos/session.py
@@ -80,6 +80,15 @@ class Session(BaseModel):
                 "Session does not exist in db, should have been checked earlier"
             )
 
+        # Complain on any differences from db
+        if (
+            self.session_id != session.session_id
+            or self.client_token != session.client_token
+            or self.user_id != session.user_id
+            or self.created_time != session.created_time
+        ):
+            raise InternalError(f"Session deviation from db: {self} vs {session}")
+
     @classmethod
     async def cleanup_expired(cls, conn: AsyncConnection) -> None:
         """Clean up expired sessions."""

--- a/user-api/container/user_api/daos/user.py
+++ b/user-api/container/user_api/daos/user.py
@@ -1,45 +1,76 @@
 from __future__ import annotations  # Postponed annotation evaluation, remove once 3.11
 
+from datetime import datetime
 from typing import Optional
 
 from psycopg.rows import class_row
 from pydantic import BaseModel, UUID4
 
 from user_api.daos.database import AsyncConnection
+from user_api.daos.utils import _verify_email_lowercase
 from user_api.exceptions import InternalError
 
 
 class User(BaseModel):
+    """A registered user."""
+
     user_id: UUID4
-    username: str
+    email_address: str
     password_hash: str
+    first_name: str
+    last_name: str
+    created_time: datetime
 
     async def create(self, conn: AsyncConnection) -> None:
         """Create the current user in the database."""
+        _verify_email_lowercase(self.email_address)
+
         if await self.find_by_id(conn, self.user_id) is not None:
             raise InternalError(
                 f"Cannot create User - id {self.user_id} already exists"
             )
-        if await self.find_by_username(conn, self.username) is not None:
-            raise InternalError(f"Cannot create User - username {self.username} taken")
+        if await self.find_by_email_address(conn, self.email_address) is not None:
+            raise InternalError(
+                f"Cannot create User - email address {self.email_address} taken"
+            )
 
         async with conn.cursor() as cur:
             await cur.execute(
-                "INSERT INTO users VALUES (%s, %s, %s)",
+                "INSERT INTO users VALUES (%s, %s, %s, %s, %s, %s)",
                 tuple(self.dict().values()),
             )
 
-    async def update_username(self, conn: AsyncConnection, new_username: str) -> None:
-        """Update the user's username if possible."""
+    async def update_email_address(
+        self, conn: AsyncConnection, new_email_address: str
+    ) -> None:
+        """Update the user's email address if possible."""
+        _verify_email_lowercase(new_email_address)
+        _verify_email_lowercase(self.email_address)
+
         await self.assert_exists(conn)
 
         async with conn.cursor() as cur:
             await cur.execute(
-                "UPDATE users SET username = %s WHERE user_id = %s",
-                (new_username, self.user_id),
+                "UPDATE users SET email_address = %s WHERE user_id = %s",
+                (new_email_address, self.user_id),
             )
 
-        self.username = new_username
+        self.email_address = new_email_address
+
+    async def update_name(
+        self, conn: AsyncConnection, new_first_name: str, new_last_name: str
+    ) -> None:
+        """Update the user's name if possible."""
+        await self.assert_exists(conn)
+
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "UPDATE users SET first_name = %s, last_name = %s WHERE user_id = %s",
+                (new_first_name, new_last_name, self.user_id),
+            )
+
+        self.first_name = new_first_name
+        self.last_name = new_last_name
 
     async def update_password_hash(
         self, conn: AsyncConnection, new_password_hash: str
@@ -76,21 +107,40 @@ class User(BaseModel):
             return await cur.fetchone()
 
     @classmethod
-    async def find_by_username(
-        cls, conn: AsyncConnection, username: str
+    async def find_by_email_address(
+        cls, conn: AsyncConnection, email_address: str
     ) -> Optional[User]:
-        """Find a user by username."""
+        """Find a user by email address."""
+        _verify_email_lowercase(email_address)
+
         async with conn.cursor(row_factory=class_row(User)) as cur:
             await cur.execute(
-                "SELECT * FROM users WHERE username = %s",
-                (username,),
+                "SELECT * FROM users WHERE email_address = %s",
+                (email_address,),
             )
             return await cur.fetchone()
 
     async def assert_exists(self, conn: AsyncConnection) -> None:
         """Raise exception if the user id doesn't exist."""
+        _verify_email_lowercase(self.email_address)
+
         user = await self.find_by_id(conn, self.user_id)
         if user is None:
             raise InternalError(
                 "User does not exist in db, should have been checked earlier"
             )
+
+        # Complain on any differences from db
+        if (
+            self.user_id != user.user_id
+            or self.email_address != user.email_address
+            or self.password_hash != user.password_hash
+            or self.first_name != user.first_name
+            or self.last_name != user.last_name
+            or self.created_time != user.created_time
+        ):
+            raise InternalError(f"User deviation from db: {self} vs {user}")
+
+    def full_email(self) -> str:
+        """Get the full email for the given user."""
+        return f"{self.first_name} {self.last_name} <{self.email_address}>"

--- a/user-api/container/user_api/daos/utils.py
+++ b/user-api/container/user_api/daos/utils.py
@@ -1,0 +1,4 @@
+def _verify_email_lowercase(email_address: str) -> None:
+    """Throw exception if email is not lowercase."""
+    if email_address != email_address.lower():
+        raise Exception("Email address should be lowercase by now")

--- a/user-api/container/user_api/exceptions.py
+++ b/user-api/container/user_api/exceptions.py
@@ -14,3 +14,9 @@ class NotFoundError(Exception):
     """Exceptions caused by access to non-existent resources."""
 
     pass
+
+
+class VerifyFailedError(Exception):
+    """Exceptions caused by failure to verify, handled by increments_failed_attempts."""
+
+    pass

--- a/user-api/container/user_api/internal/auth.py
+++ b/user-api/container/user_api/internal/auth.py
@@ -15,7 +15,7 @@ from user_api.daos import (
     PreUser,
     Session,
     User,
-    get_db_connection
+    get_db_connection,
 )
 from user_api.exceptions import (
     ClientError,

--- a/user-api/container/user_api/internal/auth.py
+++ b/user-api/container/user_api/internal/auth.py
@@ -238,6 +238,11 @@ async def request_reset_password(email_address: str) -> PasswordReset:
         if user is None:
             raise NotFoundError("Failed to find given user")
 
+        # Check if request already submitted
+        password_reset = await PasswordReset.find_by_user_id(conn, user.user_id)
+        if password_reset is not None:
+            raise ClientError("Password reset request already pending")
+
         # Make a new password reset object
         password_reset = PasswordReset(
             reset_code=uuid4(),

--- a/user-api/container/user_api/internal/auth.py
+++ b/user-api/container/user_api/internal/auth.py
@@ -1,107 +1,242 @@
 import asyncio
 from datetime import datetime
-import re
 from typing import Optional
 from uuid import uuid4
 
-import bcrypt
 from pydantic import UUID4
 
-from user_api.daos import Session, User, get_db_connection
-from user_api.exceptions import ClientError, NotFoundError
+from user_api.config import (
+    ALLOWED_FAILED_VERIFICATIONS,
+    EMAIL_ENABLED,
+    VERIFY_CODE_LENGTH,
+)
+from user_api.daos import PreUser, Session, User, get_db_connection
+from user_api.exceptions import (
+    ClientError,
+    NotFoundError,
+    VerifyFailedError,
+)
+from user_api.internal.utils import (
+    increments_failed_attempts,
+    legal_email_address,
+    legal_name,
+    legal_password,
+    legal_verify_code,
+    password_hash,
+    password_verify,
+    random_digits,
+)
+from user_api.services import email
 
 
-legal_username_re = re.compile("^[a-zA-Z0-9][a-zA-Z0-9\\-_\\.]{2,32}$")
-re_symbols = re.escape("`~!@#$%^&*()-=_+[]}{\\|;:'\",<.>/?")
-legal_password_re = re.compile(f"^[a-zA-Z0-9{re_symbols}]{{8,72}}$")
+async def preregister(email_address: str) -> PreUser:
+    """Preregister a new user, return that pre-user."""
 
-
-def _password_hash(password: str) -> str:
-    """Use bcrypt to hash a password."""
-    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt(12)).decode("utf-8")
-
-
-def _password_verify(password: str, password_hash: str) -> bool:
-    """Use bcrypt to verify a password"""
-    return bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8"))
-
-
-def _legal_username(username: str) -> bool:
-    """Is a given username legal."""
-    return re.match(legal_username_re, username) is not None
-
-
-def _legal_password(password: str) -> bool:
-    """Is a given password legal."""
-    # Validate it can be encoded to ≤72 bytes (since some chars become >1 byte in utf-8)
-    if len(password.encode("utf-8")) > 72:
-        return False
-    return re.match(legal_password_re, password) is not None
-
-
-async def register(username: str, password: str) -> User:
-    """Register a new user, return that User."""
+    email_address = email_address.lower()
 
     # Validate input is legal
-    if not _legal_username(username):
-        raise ClientError("Invalid username")
-    if not _legal_password(password):
-        raise ClientError("Invalid password")
+    if not legal_email_address(email_address):
+        raise ClientError("Invalid email address")
 
     async with await get_db_connection() as conn:
-        # Check username isn't claimed
-        existing_user = await User.find_by_username(conn, username)
+        # Check email isn't claimed
+        existing_user = await User.find_by_email_address(conn, email_address)
         if existing_user is not None:
-            raise ClientError(f"Username {username} already claimed")
+            raise ClientError(f"Email address {email_address} already claimed")
 
-        # Make a new user object
-        new_user = User(
-            user_id=uuid4(),
-            username=username,
-            password_hash=_password_hash(password),
-        )
+        # Find previous pre-registration attempt if it exists
+        pre_user = await PreUser.find_by_email_address(conn, email_address)
+        if pre_user is not None:
+            # If allowed, send a new email and bump failed verifications
+            if pre_user.failed_attempts >= ALLOWED_FAILED_VERIFICATIONS:
+                raise ClientError("Maximum failed registrations for 24 hour period")
+            await pre_user.update_verify_code(conn, random_digits(VERIFY_CODE_LENGTH))
+            # There's mild potential for abuse here that needs to be fixed
+            # If the user manages to trigger a failed attempt, but the func excs before
+            # the end of the tx, the failure increment will be rolled back
+            await pre_user.increment_failed_attempts(conn)
 
-        # Insert the user into the database
-        await new_user.create(conn)
+        else:
+            # Make a new pre-user object
+            pre_user = PreUser(
+                email_address=email_address,
+                verify_code=random_digits(VERIFY_CODE_LENGTH),
+                created_time=datetime.utcnow(),
+                failed_attempts=0,
+            )
+
+            # Insert the pre-user into the database
+            await pre_user.create(conn)
+
+        # Send verification email
+        # Keep in context manager so we don't make pre-user if email blows up
+        if EMAIL_ENABLED:
+            email.send_verification_email(
+                to_email=email_address,
+                code=pre_user.verify_code,
+            )
+
+    return pre_user
+
+
+async def preregister_verify(email_address: str, verify_code: str) -> None:
+    """Verify a given verification code. Throws execption if invalid."""
+
+    email_address = email_address.lower()
+
+    # Validate input is legal
+    if not legal_email_address(email_address):
+        raise ClientError("Invalid email address")
+    if not legal_verify_code(verify_code):
+        raise ClientError("Invalid verify code")
+
+    async with increments_failed_attempts(email_address)():
+        async with await get_db_connection() as conn:
+            # Check verification code
+            pre_user = await PreUser.find_by_email_address(conn, email_address)
+            if pre_user is None:
+                raise ClientError("Verification invalid or expired")
+            if pre_user.failed_attempts >= ALLOWED_FAILED_VERIFICATIONS:
+                raise ClientError("Maximum failed registrations for 24 hour period")
+            if verify_code != pre_user.verify_code:
+                raise VerifyFailedError("Verification code invalid")
+
+
+async def register(
+    email_address: str, password: str, first_name: str, last_name: str, verify_code: str
+) -> User:
+    """Register a new user, return that User."""
+
+    email_address = email_address.lower()
+
+    # Validate input is legal
+    if not legal_email_address(email_address):
+        raise ClientError("Invalid email address")
+    if not legal_password(password):
+        raise ClientError("Invalid password")
+    if not legal_name(first_name):
+        raise ClientError("Invalid first name")
+    if not legal_name(last_name):
+        raise ClientError("Invalid last name")
+    if not legal_verify_code(verify_code):
+        raise ClientError("Invalid verify code")
+
+    async with increments_failed_attempts(email_address)():
+        async with await get_db_connection() as conn:
+            # Check email isn't claimed
+            existing_user = await User.find_by_email_address(conn, email_address)
+            if existing_user is not None:
+                raise ClientError(f"Email address {email_address} already claimed")
+
+            # Check verification code
+            pre_user = await PreUser.find_by_email_address(conn, email_address)
+            if pre_user is None:
+                raise ClientError("Verification invalid or expired")
+
+            if pre_user.failed_attempts >= ALLOWED_FAILED_VERIFICATIONS:
+                raise ClientError("Maximum failed registrations for 24 hour period")
+
+            if verify_code != pre_user.verify_code:
+                raise VerifyFailedError("Verification code invalid")
+
+            await pre_user.delete(conn)
+
+            # Make a new user object
+            new_user = User(
+                user_id=uuid4(),
+                email_address=email_address,
+                password_hash=password_hash(password),
+                first_name=first_name,
+                last_name=last_name,
+                created_time=datetime.utcnow(),
+            )
+
+            # Insert the user into the database
+            await new_user.create(conn)
+
+            # Send email welcoming the new user
+            # Keep in context manager so we don't make user if email blows up
+            if EMAIL_ENABLED:
+                email.send_post_verification_email(
+                    new_user.full_email(), new_user.first_name
+                )
 
     return new_user
 
 
-async def change_password(username: str, new_password: str) -> None:
+async def change_name(
+    email_address: str, first_name: Optional[str], last_name: Optional[str]
+) -> None:
+    """Change a user's name."""
+    if first_name is None and last_name is None:
+        return
+
+    email_address = email_address.lower()
+
+    # Validate input
+    if not legal_email_address(email_address):
+        raise ClientError("Invalid email address")
+    if first_name is not None and not legal_name(first_name):
+        raise ClientError("Invalid first name")
+    if last_name is not None and not legal_name(last_name):
+        raise ClientError("Invalid last name")
+
+    async with await get_db_connection() as conn:
+        # Find the user
+        user = await User.find_by_email_address(conn, email_address)
+        if user is None:
+            raise NotFoundError("Failed to find given user")
+
+        # Update the user's name
+        await user.update_name(
+            conn,
+            new_first_name=first_name or user.first_name,
+            new_last_name=last_name or user.last_name,
+        )
+
+
+async def change_password(email_address: str, new_password: str) -> None:
     """Change a user's password."""
 
-    # Check new password is legal
-    if not _legal_password(new_password):
+    email_address = email_address.lower()
+
+    # Validate input
+    if not legal_email_address(email_address):
+        raise ClientError("Invalid email address")
+    if not legal_password(new_password):
         raise ClientError("Invalid password")
 
     async with await get_db_connection() as conn:
         # Find the user
-        user = await User.find_by_username(conn, username)
+        user = await User.find_by_email_address(conn, email_address)
         if user is None:
             raise NotFoundError("Failed to find given user")
 
         # Update the user's password
-        await user.update_password_hash(conn, _password_hash(new_password))
+        await user.update_password_hash(conn, password_hash(new_password))
 
 
-async def login(username: str, password: str) -> Session:
+async def login(email_address: str, password: str) -> Session:
     """Attempt to a log a user in, return session if successful."""
-    # Validate input is legal
-    if not _legal_username(username):
-        raise ClientError("Invalid username")
-    if not _legal_password(password):
+
+    email_address = email_address.lower()
+
+    # Validate input
+    if not legal_email_address(email_address):
+        raise ClientError("Invalid email address")
+    if not legal_password(password):
         raise ClientError("Invalid password")
 
     async with await get_db_connection() as conn:
         # Get the associated user
-        user = await User.find_by_username(conn, username)
+        user = await User.find_by_email_address(conn, email_address)
 
         if user is None:
-            raise ClientError("Invalid username or password")
+            raise ClientError("Invalid email address or password")
 
         # Validate the password
-        if not _password_verify(password, user.password_hash):
-            raise ClientError("Invalid username or password")
+        if not password_verify(password, user.password_hash):
+            raise ClientError("Invalid email address or password")
 
         # Make a new session object
         new_session = Session(
@@ -141,12 +276,18 @@ async def logout_by_client_token(client_token: UUID4) -> None:
         await session.delete(conn)
 
 
-async def delete(username: str) -> None:
+async def delete(email_address: str) -> None:
     """Delete a user account."""
+
+    email_address = email_address.lower()
+
+    # Validate input
+    if not legal_email_address(email_address):
+        raise ClientError("Invalid email address")
 
     async with await get_db_connection() as conn:
         # Get the user
-        user = await User.find_by_username(conn, username)
+        user = await User.find_by_email_address(conn, email_address)
         if user is None:
             raise NotFoundError("Failed to find given user")
 
@@ -168,9 +309,10 @@ async def find_by_token(client_token: UUID4) -> Optional[User]:
         return await User.find_by_id(conn, session.user_id)
 
 
-async def clean_sessions_loop() -> None:
-    """Loop to clean sessions regularly."""
+async def clean_db_loop() -> None:
+    """Loop to clean db stuff regularly."""
     while True:
         async with await get_db_connection() as conn:
             await Session.cleanup_expired(conn)
+            await PreUser.cleanup_expired(conn)
             await asyncio.sleep(3600)

--- a/user-api/container/user_api/internal/auth.py
+++ b/user-api/container/user_api/internal/auth.py
@@ -10,7 +10,13 @@ from user_api.config import (
     EMAIL_ENABLED,
     VERIFY_CODE_LENGTH,
 )
-from user_api.daos import PreUser, Session, User, get_db_connection
+from user_api.daos import (
+    PasswordReset,
+    PreUser,
+    Session,
+    User,
+    get_db_connection
+)
 from user_api.exceptions import (
     ClientError,
     NotFoundError,
@@ -313,6 +319,7 @@ async def clean_db_loop() -> None:
     """Loop to clean db stuff regularly."""
     while True:
         async with await get_db_connection() as conn:
-            await Session.cleanup_expired(conn)
+            await PasswordReset.cleanup_expired(conn)
             await PreUser.cleanup_expired(conn)
+            await Session.cleanup_expired(conn)
             await asyncio.sleep(3600)

--- a/user-api/container/user_api/internal/utils.py
+++ b/user-api/container/user_api/internal/utils.py
@@ -1,0 +1,114 @@
+import bcrypt
+from contextlib import asynccontextmanager
+import re
+from secrets import randbelow
+from typing import (
+    Any,
+    AsyncGenerator,
+    AsyncContextManager,
+    Callable,
+    Dict,
+    List,
+)
+
+from user_api.config import VERIFY_CODE_LENGTH
+from user_api.daos import PreUser, get_db_connection
+from user_api.exceptions import ClientError, InternalError, VerifyFailedError
+
+
+legal_email_address_re = re.compile(r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")
+re_symbols = re.escape("`~!@#$%^&*()-=_+[]}{\\|;:'\",<.>/?")
+legal_password_re = re.compile(f"^[a-zA-Z0-9{re_symbols}]{{8,72}}$")
+legal_name_re = re.compile(r"^[a-zA-Z-]+$")
+legal_verify_code_re = re.compile(f"^[0-9]{{{VERIFY_CODE_LENGTH}}}$")
+
+
+def password_hash(password: str) -> str:
+    """Use bcrypt to hash a password."""
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt(12)).decode("utf-8")
+
+
+def password_verify(password: str, password_hash: str) -> bool:
+    """Use bcrypt to verify a password"""
+    return bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8"))
+
+
+def legal_email_address(email_address: str) -> bool:
+    """Is a given email address legal."""
+    if email_address != email_address.lower():
+        raise Exception("Email address should be lowercase by now")
+    if len(email_address.encode("utf-8")) > 320:
+        return False
+    return re.match(legal_email_address_re, email_address) is not None
+
+
+def legal_password(password: str) -> bool:
+    """Is a given password legal."""
+    # Validate it can be encoded to ≤72 bytes (since some chars become >1 byte in utf-8)
+    if len(password.encode("utf-8")) > 72:
+        return False
+    return re.match(legal_password_re, password) is not None
+
+
+def legal_name(name: str) -> bool:
+    if len(name.encode("utf-8")) > 32:
+        return False
+    return re.match(legal_name_re, name) is not None
+
+
+def legal_verify_code(verify_code: str) -> bool:
+    return re.match(legal_verify_code_re, verify_code) is not None
+
+
+def random_digits(length: int) -> str:
+    """Securely generate a given number of digits as a string."""
+    digits = [str(randbelow(10)) for i in range(length)]
+    return "".join(digits)
+
+
+async def increment_failed_attempts(email_address: str, amount: int = 1) -> None:
+    """Increment the failed registration attempts for an email.
+
+    This should be done in separate tx so the failure increment doesn't get trashed by
+    the transaction rollback which will occur if ClientError or unexpected error occurs
+    after increment.
+    """
+    async with await get_db_connection() as conn:
+        pre_user = await PreUser.find_by_email_address(conn, email_address)
+        if pre_user is None:
+            raise InternalError(
+                "Internal _increment_failed_attempts called with invalid PreUser"
+            )
+
+        await pre_user.increment_failed_attempts(conn, amount=amount)
+
+
+def increments_failed_attempts(
+    email_address: str,
+) -> Callable[..., AsyncContextManager[None]]:
+    """Generate context manager for a given email address."""
+
+    email_address = email_address.lower()
+
+    # Validate input is legal
+    if not legal_email_address(email_address):
+        raise ClientError("Invalid email address")
+
+    @asynccontextmanager
+    async def _increments_failed_attempts_inner(
+        *args: List[Any], **kwargs: Dict[Any, Any]
+    ) -> AsyncGenerator[None, None]:
+        """Context manager to increment failed verification attempts as necessary.
+
+        Any raised VerifyFailedErrors trigger failure increment and are re-raised as
+        ClientErrors.
+        """
+        try:
+            yield
+        except VerifyFailedError as e:
+            await increment_failed_attempts(email_address)
+            raise ClientError(str(e))
+        finally:
+            pass
+
+    return _increments_failed_attempts_inner

--- a/user-api/container/user_api/routers/api_models.py
+++ b/user-api/container/user_api/routers/api_models.py
@@ -1,6 +1,14 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, UUID4
+
+
+class PasswordResetCreateRequest(BaseModel):
+    email_address: str
+
+
+class PasswordResetCreateResponse(BaseModel):
+    reset_code: Optional[str]
 
 
 class PreUserCreateRequest(BaseModel):
@@ -26,6 +34,12 @@ class UserCreateRequest(BaseModel):
     first_name: str
     last_name: str
     verify_code: str
+
+
+class UserResetPasswordRequest(BaseModel):
+    email_address: str
+    password: str
+    reset_code: UUID4
 
 
 class UserLoginRequest(BaseModel):

--- a/user-api/container/user_api/routers/api_models.py
+++ b/user-api/container/user_api/routers/api_models.py
@@ -28,10 +28,6 @@ class UserCreateRequest(BaseModel):
     verify_code: str
 
 
-class UserDeleteRequest(BaseModel):
-    email_address: str
-
-
 class UserLoginRequest(BaseModel):
     email_address: str
     password: str

--- a/user-api/container/user_api/routers/api_models.py
+++ b/user-api/container/user_api/routers/api_models.py
@@ -1,21 +1,48 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 
-class AuthLoginResponse(BaseModel):
-    client_token: str
+class PreUserCreateRequest(BaseModel):
+    email_address: str
 
 
-class UserCreateRequest(BaseModel):
-    password: str
+class PreUserCreateResponse(BaseModel):
+    verify_code: Optional[str]
 
 
-class UserUpdateRequest(BaseModel):
-    password: str
-
-
-class UserLoginRequest(BaseModel):
-    password: str
+class PreUserVerifyRequest(BaseModel):
+    email_address: str
+    verify_code: str
 
 
 class TokenGetResponse(BaseModel):
-    username: str
+    email_address: str
+
+
+class UserCreateRequest(BaseModel):
+    email_address: str
+    password: str
+    first_name: str
+    last_name: str
+    verify_code: str
+
+
+class UserDeleteRequest(BaseModel):
+    email_address: str
+
+
+class UserLoginRequest(BaseModel):
+    email_address: str
+    password: str
+
+
+class UserLoginResponse(BaseModel):
+    client_token: str
+
+
+class UserUpdateRequest(BaseModel):
+    email_address: str
+    password: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None

--- a/user-api/container/user_api/routers/api_models.py
+++ b/user-api/container/user_api/routers/api_models.py
@@ -8,7 +8,7 @@ class PasswordResetCreateRequest(BaseModel):
 
 
 class PasswordResetCreateResponse(BaseModel):
-    reset_code: Optional[str]
+    reset_code: Optional[UUID4]
 
 
 class PreUserCreateRequest(BaseModel):

--- a/user-api/container/user_api/routers/auth.py
+++ b/user-api/container/user_api/routers/auth.py
@@ -92,7 +92,7 @@ async def user_delete(email_address: str) -> Response:
     return success
 
 
-@router.post("/password_reset")
+@router.post("/password_resets")
 async def password_reset_create(
     password_reset_create_request: api_models.PasswordResetCreateRequest,
 ) -> api_models.PasswordResetCreateResponse:

--- a/user-api/container/user_api/routers/auth.py
+++ b/user-api/container/user_api/routers/auth.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Response, status
 from pydantic import UUID4
 
+from user_api.config import EMAIL_ENABLED
 from user_api.exceptions import NotFoundError
 from user_api.internal import auth
 from user_api.routers import api_models
@@ -12,52 +13,98 @@ router = APIRouter()
 success = Response(status_code=status.HTTP_200_OK)
 
 
-@router.post("/users/{username}")
+@router.post("/pre_users")
+async def pre_user_create(
+    pre_user_create_request: api_models.PreUserCreateRequest,
+) -> api_models.PreUserCreateResponse:
+    """Create a pre-user (unverified email address)."""
+    with sanitize_excs():
+        pre_user = await auth.preregister(
+            email_address=pre_user_create_request.email_address,
+        )
+        # If email disabled, pass verify code right back to user
+        verify_code = None if EMAIL_ENABLED else pre_user.verify_code
+        resp = api_models.PreUserCreateResponse(verify_code=verify_code)
+    return resp
+
+
+@router.post("/pre_users/verify")
+async def pre_user_verify(
+    pre_user_verify_request: api_models.PreUserVerifyRequest,
+) -> Response:
+    """Verify a pre-user verification code."""
+    with sanitize_excs():
+        # Raises exc if verification fails
+        await auth.preregister_verify(
+            email_address=pre_user_verify_request.email_address,
+            verify_code=pre_user_verify_request.verify_code,
+        )
+    return success
+
+
+@router.post("/users")
 async def user_create(
-    username: str,
     user_create_request: api_models.UserCreateRequest,
 ) -> Response:
     """Register a new user."""
     with sanitize_excs():
+        # Don't expand with ** to avoid leaking request fields
         await auth.register(
-            username=username,
+            email_address=user_create_request.email_address,
             password=user_create_request.password,
+            first_name=user_create_request.first_name,
+            last_name=user_create_request.last_name,
+            verify_code=user_create_request.verify_code,
         )
     return success
 
 
-@router.put("/users/{username}")
+@router.put("/users")
 async def user_update(
-    username: str,
     user_update_request: api_models.UserUpdateRequest,
 ) -> Response:
-    """Change a authenticated user's password."""
+    """Change a user's information."""
     with sanitize_excs():
-        await auth.change_password(username, user_update_request.password)
+        if user_update_request.password is not None:
+            # Don't expand with ** to avoid leaking request fields
+            await auth.change_password(
+                email_address=user_update_request.email_address,
+                new_password=user_update_request.password,
+            )
+        if (
+            user_update_request.first_name is not None
+            or user_update_request.last_name is not None
+        ):
+            # Don't expand with ** to avoid leaking request fields
+            await auth.change_name(
+                email_address=user_update_request.email_address,
+                first_name=user_update_request.first_name,
+                last_name=user_update_request.last_name,
+            )
     return success
 
 
-@router.delete("/users/{username}")
-async def user_delete(username: str) -> Response:
+@router.delete("/users")
+async def user_delete(user_delete_request: api_models.UserDeleteRequest) -> Response:
     """Delete a user account."""
     with sanitize_excs():
-        await auth.delete(username)
+        await auth.delete(email_address=user_delete_request.email_address)
     return success
 
 
 # This is essentially the token create endpoint, it just has specific requirements
-@router.post("/users/{username}/login")
+@router.post("/users/login")
 async def user_login(
-    username: str,
     user_login_request: api_models.UserLoginRequest,
-) -> api_models.AuthLoginResponse:
+) -> api_models.UserLoginResponse:
     """Log a user in."""
     with sanitize_excs():
         session = await auth.login(
-            username=username,
+            email_address=user_login_request.email_address,
             password=user_login_request.password,
         )
-    return api_models.AuthLoginResponse(client_token=session.client_token.hex)
+        resp = api_models.UserLoginResponse(client_token=session.client_token.hex)
+    return resp
 
 
 @router.get("/tokens/{client_token}")
@@ -67,7 +114,8 @@ async def token_get(client_token: UUID4) -> api_models.TokenGetResponse:
         user = await auth.find_by_token(client_token)
         if user is None:
             raise NotFoundError("Failed to find token")
-    return api_models.TokenGetResponse(username=user.username)
+        resp = api_models.TokenGetResponse(email_address=user.email_address)
+    return resp
 
 
 @router.delete("/tokens/{client_token}")

--- a/user-api/container/user_api/routers/auth.py
+++ b/user-api/container/user_api/routers/auth.py
@@ -92,6 +92,35 @@ async def user_delete(email_address: str) -> Response:
     return success
 
 
+@router.post("/password_reset")
+async def password_reset_create(
+    password_reset_create_request: api_models.PasswordResetCreateRequest,
+) -> api_models.PasswordResetCreateResponse:
+    """Request a password reset."""
+    with sanitize_excs():
+        password_reset = await auth.request_reset_password(
+            email_address=password_reset_create_request.email_address,
+        )
+        # If email is disabled, pass reset code right back to user
+        reset_code = None if EMAIL_ENABLED else password_reset.reset_code
+        resp = api_models.PasswordResetCreateResponse(reset_code=reset_code)
+    return resp
+
+
+@router.post("/users/reset_password")
+async def user_reset_password(
+    user_reset_password_request: api_models.UserResetPasswordRequest,
+) -> Response:
+    """Reset a user's password, provided the reset_code is correct."""
+    with sanitize_excs():
+        await auth.reset_password(
+            email_address=user_reset_password_request.email_address,
+            new_password=user_reset_password_request.password,
+            reset_code=user_reset_password_request.reset_code,
+        )
+    return success
+
+
 # This is essentially the token create endpoint, it just has specific requirements
 @router.post("/users/login")
 async def user_login(

--- a/user-api/container/user_api/routers/auth.py
+++ b/user-api/container/user_api/routers/auth.py
@@ -85,10 +85,10 @@ async def user_update(
 
 
 @router.delete("/users")
-async def user_delete(user_delete_request: api_models.UserDeleteRequest) -> Response:
+async def user_delete(email_address: str) -> Response:
     """Delete a user account."""
     with sanitize_excs():
-        await auth.delete(email_address=user_delete_request.email_address)
+        await auth.delete(email_address=email_address)
     return success
 
 

--- a/user-api/container/user_api/routers/main.py
+++ b/user-api/container/user_api/routers/main.py
@@ -27,7 +27,12 @@ app.include_router(auth.router)
 
 @app.on_event("startup")
 async def app_startup() -> None:
-    """Start background tasks."""
+    """Verify config, start background tasks."""
+    # Validate env vars set
+    if any([var is None for var in config.REQUIRED_ENV_FOR_DEPLOY]):
+        raise Exception(f"Missing required env vars: {config.REQUIRED_ENV_FOR_DEPLOY}")
+
+    # Start cleaning expired sessions
     asyncio.create_task(clean_sessions_loop())
 
 

--- a/user-api/container/user_api/routers/main.py
+++ b/user-api/container/user_api/routers/main.py
@@ -7,7 +7,7 @@ from psycopg.types.json import set_json_dumps, set_json_loads
 import orjson
 
 from user_api import config
-from user_api.internal.auth import clean_sessions_loop
+from user_api.internal.auth import clean_db_loop
 from user_api.routers import auth
 
 
@@ -32,11 +32,11 @@ async def app_startup() -> None:
     if any([var is None for var in config.REQUIRED_ENV_FOR_DEPLOY]):
         raise Exception(f"Missing required env vars: {config.REQUIRED_ENV_FOR_DEPLOY}")
 
-    # Start cleaning expired sessions
-    asyncio.create_task(clean_sessions_loop())
+    # Start cleaning stuff up
+    asyncio.create_task(clean_db_loop())
 
 
 @app.get("/ping", response_class=PlainTextResponse)
-def root() -> str:
+def ping() -> str:
     """Ping pong."""
     return "pong"

--- a/user-api/container/user_api/routers/utils.py
+++ b/user-api/container/user_api/routers/utils.py
@@ -3,7 +3,12 @@ from typing import Any, Dict, Iterator, List
 
 from fastapi import HTTPException
 
-from user_api.exceptions import ClientError, InternalError, NotFoundError
+from user_api.exceptions import (
+    ClientError,
+    InternalError,
+    NotFoundError,
+    VerifyFailedError,
+)
 
 
 @contextmanager
@@ -11,6 +16,9 @@ def sanitize_excs(*args: List[Any], **kwargs: Dict[Any, Any]) -> Iterator[None]:
     """Context manager to sanitize exceptions."""
     try:
         yield
+    except VerifyFailedError as e:
+        print(f"VERIFY FAILED ERROR ESCAPED: {str(e)}")  # TODO make this a log crit
+        raise HTTPException(status_code=500)
     except InternalError as e:
         print(f"INTERNAL ERROR: {str(e)}")  # TODO make this a log error
         raise HTTPException(status_code=500)

--- a/user-api/container/user_api/services/email/__init__.py
+++ b/user-api/container/user_api/services/email/__init__.py
@@ -1,5 +1,6 @@
 from user_api.services.email.client import send_email
 from user_api.services.email.premade import (
+    send_password_reset_email,
     send_post_verification_email,
     send_test_email,
     send_verification_email,
@@ -7,6 +8,7 @@ from user_api.services.email.premade import (
 
 __all__ = [
     "send_email",
+    "send_password_reset_email",
     "send_post_verification_email",
     "send_test_email",
     "send_verification_email",

--- a/user-api/container/user_api/services/email/__init__.py
+++ b/user-api/container/user_api/services/email/__init__.py
@@ -1,7 +1,13 @@
 from user_api.services.email.client import send_email
-from user_api.services.email.premade import send_test_email
+from user_api.services.email.premade import (
+    send_post_verification_email,
+    send_test_email,
+    send_verification_email,
+)
 
 __all__ = [
     "send_email",
+    "send_post_verification_email",
     "send_test_email",
+    "send_verification_email",
 ]

--- a/user-api/container/user_api/services/email/__init__.py
+++ b/user-api/container/user_api/services/email/__init__.py
@@ -1,0 +1,7 @@
+from user_api.services.email.client import send_email
+from user_api.services.email.premade import send_test_email
+
+__all__ = [
+    "send_email",
+    "send_test_email",
+]

--- a/user-api/container/user_api/services/email/client.py
+++ b/user-api/container/user_api/services/email/client.py
@@ -3,7 +3,7 @@ from typing import List
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail, MailSettings, SandBoxMode
 
-from user_api.config import EMAIL_FROM, SENDGRID_KEY
+from user_api.config import EMAIL_ENABLED, EMAIL_FROM, SENDGRID_KEY
 from user_api.exceptions import InternalError
 
 
@@ -15,7 +15,7 @@ def send_email(
     sandbox: bool = False,
 ) -> None:
     """Send email to the given addresses."""
-    if SENDGRID_KEY is None:
+    if not EMAIL_ENABLED or SENDGRID_KEY is None:
         raise InternalError("Cannot send mail without sendgrid key")
 
     message = Mail(

--- a/user-api/container/user_api/services/email/client.py
+++ b/user-api/container/user_api/services/email/client.py
@@ -3,16 +3,21 @@ from typing import List
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail, MailSettings, SandBoxMode
 
-from user_api.config import EMAIL_FROM, SENDGRID_KEY, TEST_MODE
+from user_api.config import EMAIL_FROM, SENDGRID_KEY
+from user_api.exceptions import InternalError
 
 
 def send_email(
     to_emails: List[str],
     subject: str,
     html_content: str,
-    from_email=EMAIL_FROM,
+    from_email: str = EMAIL_FROM,
+    sandbox: bool = False,
 ) -> None:
     """Send email to the given addresses."""
+    if SENDGRID_KEY is None:
+        raise InternalError("Cannot send mail without sendgrid key")
+
     message = Mail(
         from_email=from_email,
         to_emails=to_emails,
@@ -20,13 +25,13 @@ def send_email(
         html_content=html_content,
     )
 
-    if TEST_MODE:
+    if sandbox:
         mail_settings = MailSettings(sandbox_mode=SandBoxMode(True))
         message.mail_settings = mail_settings
 
     sg = SendGridAPIClient(SENDGRID_KEY)
     response = sg.send(message)
 
-    expected_status = 200 if TEST_MODE else 202
+    expected_status = 200 if sandbox else 202
     if response.status_code != expected_status:
         raise Exception(f"Got unexpected mail status: {response.status_code}")

--- a/user-api/container/user_api/services/email/client.py
+++ b/user-api/container/user_api/services/email/client.py
@@ -1,0 +1,32 @@
+from typing import List
+
+from sendgrid import SendGridAPIClient
+from sendgrid.helpers.mail import Mail, MailSettings, SandBoxMode
+
+from user_api.config import EMAIL_FROM, SENDGRID_KEY, TEST_MODE
+
+
+def send_email(
+    to_emails: List[str],
+    subject: str,
+    html_content: str,
+    from_email=EMAIL_FROM,
+) -> None:
+    """Send email to the given addresses."""
+    message = Mail(
+        from_email=from_email,
+        to_emails=to_emails,
+        subject=subject,
+        html_content=html_content,
+    )
+
+    if TEST_MODE:
+        mail_settings = MailSettings(sandbox_mode=SandBoxMode(True))
+        message.mail_settings = mail_settings
+
+    sg = SendGridAPIClient(SENDGRID_KEY)
+    response = sg.send(message)
+
+    expected_status = 200 if TEST_MODE else 202
+    if response.status_code != expected_status:
+        raise Exception(f"Got unexpected mail status: {response.status_code}")

--- a/user-api/container/user_api/services/email/premade.py
+++ b/user-api/container/user_api/services/email/premade.py
@@ -29,3 +29,15 @@ def send_post_verification_email(to_email: str, first_name: str) -> None:
         subject=subject,
         html_content=content,
     )
+
+
+def send_password_reset_email(to_email: str, reset_code: str) -> None:
+    """Send an email with a password reset code."""
+    # TODO make this a webpage with the code as a qsp in a link
+    subject = "[Web Games] Reset your password"
+    content = f"You requested a password reset. Your code is {reset_code}"
+    send_email(
+        to_emails=[to_email],
+        subject=subject,
+        html_content=content,
+    )

--- a/user-api/container/user_api/services/email/premade.py
+++ b/user-api/container/user_api/services/email/premade.py
@@ -1,0 +1,10 @@
+from user_api.services.email.client import send_email
+
+
+def send_test_email(to_email: str) -> None:
+    """Send a generic test email."""
+    send_email(
+        to_emails=[to_email],
+        subject="Test email",
+        html_content="This is a test email",
+    )

--- a/user-api/container/user_api/services/email/premade.py
+++ b/user-api/container/user_api/services/email/premade.py
@@ -8,3 +8,24 @@ def send_test_email(to_email: str) -> None:
         subject="Test email",
         html_content="This is a test email",
     )
+
+
+def send_verification_email(to_email: str, code: str) -> None:
+    """Send an email address confirmation email."""
+    content = f"Your email verification code is {code}"
+    send_email(
+        to_emails=[to_email],
+        subject="[Web Games] Confirm your email address",
+        html_content=content,
+    )
+
+
+def send_post_verification_email(to_email: str, first_name: str) -> None:
+    """Send an email welcoming the user and confirming verification."""
+    subject = f"Welcome to Web Games, {first_name}"
+    content = "Your verification was successful. Log in now!"
+    send_email(
+        to_emails=[to_email],
+        subject=subject,
+        html_content=content,
+    )

--- a/user-api/container/user_api/services/email/premade.py
+++ b/user-api/container/user_api/services/email/premade.py
@@ -10,9 +10,9 @@ def send_test_email(to_email: str) -> None:
     )
 
 
-def send_verification_email(to_email: str, code: str) -> None:
+def send_verification_email(to_email: str, verify_code: str) -> None:
     """Send an email address confirmation email."""
-    content = f"Your email verification code is {code}"
+    content = f"Your email verification code is {verify_code}"
     send_email(
         to_emails=[to_email],
         subject="[Web Games] Confirm your email address",

--- a/user-api/helm/user-api/garden.yaml
+++ b/user-api/helm/user-api/garden.yaml
@@ -37,6 +37,12 @@ devMode:
       exclude:
         - "**/__pycache__/**/*"
       mode: one-way-replica
+    - source: stubs
+      target: /src/stubs
+      mode: one-way-replica
+    - source: tests
+      target: /src/tests
+      mode: one-way-replica
 tests:
   - name: integration
     dependencies:

--- a/user-api/helm/user-api/templates/deployment.yaml
+++ b/user-api/helm/user-api/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.sendgrid.required (empty .Values.sendgrid.secretName) -}}
+{{ fail "sendgrid secret name required" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,6 +49,12 @@ spec:
             - name: EXPECTED_PREFIX
               value: {{ .Values.ingress.prefix | quote }}
             {{- end }}
+            - name: SENDGRID_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: sendgridKey
+                  name: {{ default "sendgrid" .Values.sendgrid.secretName }}
+                  optional: {{ not .Values.sendgrid.required }}
           image: {{ printf "%s:%s" .Values.image.repository .Values.image.tag | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: uvicorn

--- a/user-api/helm/user-api/values.prod.yaml
+++ b/user-api/helm/user-api/values.prod.yaml
@@ -1,2 +1,6 @@
 ingress:
   enabled: false  # WE DEFINITELY DON'T WANT THIS EXPOSED IN PROD
+
+sendgrid:
+  required: true
+  secretName: sendgrid

--- a/user-api/helm/user-api/values.yaml
+++ b/user-api/helm/user-api/values.yaml
@@ -17,3 +17,7 @@ ingress:
   tls:
     enabled: false
     secretName:
+
+sendgrid:
+  required: false
+  secretName:

--- a/webgames.sublime-project
+++ b/webgames.sublime-project
@@ -1,0 +1,12 @@
+{
+	"folders":
+	[
+		{
+			"path": ".",
+			"folder_exclude_patterns":
+			[
+				".garden"
+			],
+		}
+	],
+}


### PR DESCRIPTION
Using sendgrid's platform, as much as I hate adding another dependency.

For now, will serve only to confirm email addresses of users and reset passwords. Sendgrid is an optional dependency, if the sendgrid api key secret doesn't exist (and isn't marked as expected in the kube config) nothing blows up until `send_email` is called.

This PR incurs a major change to the database structure, so we're just remaking the user-api db in prod post-merge (benefits of having no user data to migrate 🥳).

This PR changes user-api from using `username` as the primary key to using `email` as the primary key. As fallout, user-api's interface is a bit less REST-ful now, as we can't (and shouldn't have in the first place) use `username` in path parameters. For examples of path changes:
* Creating a user - `POST /users/{username} -> POST /users`, json payload now includes email address.
* Logging a user in - `POST /users/{username}/login -> POST /users/login`, json payload now includes email address.
* etc

This PR adds a `pre_users` table to the database and a matching `PreUser` DAO. This tracks email addresses that have requested to register, the verification codes for those emails, and how many failed verifications have occurred (to prevent brute-forcing the 6-digit code). Some of the relevant code feels overcomplex (see `increments_failed_attempts` asynchronous context manager factory function), but I fail to see a better solution given that `psycopg` apparently causes 504s and 502s when you try to open a connection while inside an existing connection's context manager.

The dependency on sendgrid is made soft, and the auth pathway changes depending on sendgrid being available. If a sendgrid api key is provided, email verification is required. If a sendgrid api key is not provided, the verification code is returned immediately by the pre-register endpoint, allowing a consumer to register without email. This email-free pathway should only be used in dev environments and unit/integration tests.